### PR TITLE
change config to allow exporting of multiple generators and refiners

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,36 @@
 #+tags:
 
 * changelog
+** Upcoming
+*** Breaking
+    + The =generators= configuration key is now a new structure and will break
+      old consumers' configuration files. Instead of a flat input/output file
+      mapping, each pairing is represented with a structure that indicates
+      (still) an input and output file, but also input and output exports.
+      Consumers will now need to identify the exports to be used (rather than
+      assuming =default=) and indicate how those identifiers map to a generated
+      version.
+    + Consumers can no longer import the =default= of generated files. Instead
+      consumers must indicate specific exported identifiers.
+    + There is a verbiage change in the works to stop using the word
+      "deserializer" due to its inaccuracy. Instead "refiner" is preferred. The
+      input these generated functions take is already deserialized. "Validator"
+      is a poor term. While =flow-degen= might be able to ensure the =structure=
+      of data is valid, there are many ways to go about being valid such as
+      accounting for state machine transitions or making sure a user token
+      hasn't expired. Perhaps one could make the generated functions do these
+      things, this has not been the focus of this library. Ultimately
+      =flow-degen= is about taking in some unknown input and emitting an
+      expected structure or an error detailing why the input doesn't satisfy the
+      requirements.
+*** Additions
+    + An example of how to use =degenString= has been added.
+    + An example of how to put together a custom generator has been added.
+    + Configuration files can now indicate multiple refiners per file (both
+      input and output). This paves the way for recursion - a feature in the
+      near future. It also allows the refiner code to become significantly
+      smaller when arranged for re-use.
+*** Fixes
 ** 0.9.0
 *** Breaking
     + The new =generatedPreamble= field is required and will break

--- a/README.org
+++ b/README.org
@@ -42,7 +42,13 @@ yarn add -E -D flow-degen
     "baseDir": "",
     "generatedPreamble": "",
     "generators": [
-      ["deserializer-output-file.js", "./dir/generator-input-file.js"]
+      {
+        "exports": {
+          "fooGenerator": "fooRefiner",
+        },
+        "inputFile": "./dir/generator-input-file.js",
+        "outputFile": "deserializer-output-file.js"
+      }
     ],
     "importLocations": {
       "importName": "./dir/runtime.js"
@@ -61,9 +67,33 @@ yarn add -E -D flow-degen
     rules (such as disabling ESLint's [[https://eslint.org/docs/rules/no-unused-expressions][no-used-expressions]] rule which can be an
     issue for disjoint unions).
 *** generators
-    This is a list of deserializers and their associated generators as tuples.
-    You can have multiple here to cover all of your deserializers for your
-    project.
+    This is a list of generators and how they produce refiners. Generators here
+    have the following structure:
+
+    #+begin_src json
+      {
+        "exports": {
+          "fooGenerator": "fooRefiner",
+          "barGenerator": "barRefiner",
+          "bazGenerator": "bazRefiner"
+        },
+        "inputFile": "foo-generator.js",
+        "outputFile": "foo-refiner.js"
+      }
+    #+end_src
+
+**** exports
+     =exports= is a mapping of identifiers exported from the generator file that
+     =flow-degen= can find, and it maps to identifiers it will generate as
+     refiners for that associated generator. In the sample configuration,
+     =fooGenerator= is found in =foo-generator.js=, and it will emit a
+     =fooRefiner= to =foo-refiner.js= that you can then =import= or =require=
+     to use.
+
+     =exports= is also implicitly added to =importLocations= such that your
+     refiners can refer to each other, and even achieve recursive calls if your
+     structure requires recursion.
+
 *** importLocations
     This is a mapping of import names (which must be valid JavaScript
     identifiers) to files. The identifiers must map to =export= entities inside
@@ -101,6 +131,30 @@ yarn add -E -D flow-degen
      of the object and a list of fields that =degenField= can emit.
 **** degenString
      The =degenString= deserializer simply deserializes a value as a =string=.
+
+     Say we have a =name-generator.js=:
+     #+begin_src js
+       import { degenString } from 'flow-degen'
+       export const nameGenerator = () => degenString()
+     #+end_src
+
+     And this is configured to produce a =name-refiner.js=, this is how it would
+     be used:
+     #+begin_src js
+       import { nameRefiner } from './name-refiner.js'
+
+       // This could be an HTTP POST handler on a server, or a form handler on a UI
+       handleUnsanitizedInput((input) => {
+         const nameOrError: string | Error = nameRefiner(input)
+         if(nameOrError instanceof Error) {
+           console.error(nameOrError)
+         } else {
+           // Here can we use the name.
+           storeName(nameOrError)
+         }
+       })
+     #+end_src
+
 **** degenSentinelValue
      This deserializer is to be used in conjunction with =degenSum= to produce
      deserializers for a sum type. This represents one member of the union. It
@@ -142,6 +196,40 @@ yarn add -E -D flow-degen
       =./src/generator.js= does this for you. It is found by =flow-degen=
       consumers as a top-level export (=import { mergeDeps } from
       'flow-degen'=).
+
+    Let's create an custom generator example where we have an uppercase string.
+
+    #+begin_src js
+      import {
+        degenString,
+        mergeDeps,
+        type DeserializerGenerator,
+      } from 'flow-degen'
+      import { uppercase } from './my-string-utils.js'
+
+      export const degenUppercaseString = <CustomType: string, CustomImport: string>(
+      ): DeserializerGenerator<CustomType, CustomImport> => {
+        const [ stringGenerator, stringDeps ] = degenString()
+        return [
+          `(x: mixed): string => {
+             return uppercase(${stringGenerator})
+          }`,
+          mergeDeps(
+            stringDeps,
+            {
+              hoists: [],
+              imports: [ 'uppercase' ],
+              types: [],
+            },
+          ),
+        ]
+      }
+    #+end_src
+
+    Custom generators are no different from the built-in generators. The
+    built-in generators in =src/generators.js= can be used as more complex
+    examples for building your own generators.
+
 *** command line
 Once installed, you can use the =flow-degen= script to generate your
 deserializers:

--- a/meta-config.json
+++ b/meta-config.json
@@ -2,7 +2,13 @@
   "baseDir": "",
   "generatedPreamble": "",
   "generators": [
-    ["src/config.deserializer.js", "./src/config-generator.js"]
+    {
+      "inputFile": "./src/config-generator.js",
+      "outputFile": "src/config.deserializer.js",
+      "exports": {
+        "degenConfig": "deConfig"
+      }
+    }
   ],
   "importLocations": {
     "deField": "./deserializer.js",
@@ -11,6 +17,7 @@
     "deString": "./deserializer.js"
   },
   "typeLocations": {
-    "Config": "./config-generator.js"
+    "Config": "./config-generator.js",
+    "ConfigGenerator": "./config-generator.js"
   }
 }

--- a/src/config-generator.js
+++ b/src/config-generator.js
@@ -10,22 +10,33 @@ import {
   degenType,
 } from './generator.js'
 
+export type ConfigGenerator = {
+  exports: {[string]: string},
+  inputFile: string,
+  outputFile: string,
+}
+
 export type Config<CustomType: string, CustomImport: string> = {
   baseDir: string,
   generatedPreamble: string,
   // TODO: Support tuples.
-  generators: Array<Array<string>>,
+  generators: Array<ConfigGenerator>,
   importLocations: {[CustomImport]: string},
   typeLocations: {[CustomType]: string},
 }
 
 const stringType = { name: 'string', typeParams: [] }
 const configType = { name: 'Config', typeParams: [ stringType, stringType ]}
+const configGeneratorType = { name: 'ConfigGenerator', typeParams: []}
 
-export default () => degenObject<string, string>(configType, [
+export const degenConfig = () => degenObject<string, string>(configType, [
   degenField('baseDir', degenString()),
   degenField('generatedPreamble', degenString()),
   degenField('typeLocations', degenMapping(degenString(), degenString())),
   degenField('importLocations', degenMapping(degenString(), degenString())),
-  degenField('generators', degenList(degenList(degenFilePath()))),
+  degenField('generators', degenList(degenObject(configGeneratorType, [
+    degenField('exports', degenMapping(degenString(), degenString())),
+    degenField('inputFile', degenString()),
+    degenField('outputFile', degenString()),
+  ]))),
 ])

--- a/src/config-generator.js
+++ b/src/config-generator.js
@@ -30,13 +30,13 @@ const configType = { name: 'Config', typeParams: [ stringType, stringType ]}
 const configGeneratorType = { name: 'ConfigGenerator', typeParams: []}
 
 export const degenConfig = () => degenObject<string, string>(configType, [
-  degenField('baseDir', degenString()),
+  degenField('baseDir', degenFilePath()),
   degenField('generatedPreamble', degenString()),
-  degenField('typeLocations', degenMapping(degenString(), degenString())),
-  degenField('importLocations', degenMapping(degenString(), degenString())),
+  degenField('typeLocations', degenMapping(degenString(), degenFilePath())),
+  degenField('importLocations', degenMapping(degenString(), degenFilePath())),
   degenField('generators', degenList(degenObject(configGeneratorType, [
     degenField('exports', degenMapping(degenString(), degenString())),
-    degenField('inputFile', degenString()),
-    degenField('outputFile', degenString()),
+    degenField('inputFile', degenFilePath()),
+    degenField('outputFile', degenFilePath()),
   ]))),
 ])

--- a/test/exhaustive-union.js
+++ b/test/exhaustive-union.js
@@ -80,7 +80,7 @@ const code = codeGen(
     deBool: '../src/deserializer.js',
   },
   [
-    [ path.resolve(__dirname, 'exhuastive-union-test-output.js'), generator() ],
+    [ path.resolve(__dirname, 'exhuastive-union-test-output.js'), [[ 'union', generator() ]] ],
   ],
 )[0][1]
 

--- a/test/flow-strict.js
+++ b/test/flow-strict.js
@@ -14,7 +14,7 @@ const code = codeGen(
   {},
   { stringify: '../src/deserializer.js', deString: '../src/deserializer.js' },
   [
-    [ path.resolve(__dirname, 'flow-strict-output.js'), generator() ],
+    [ path.resolve(__dirname, 'flow-strict-output.js'), [['strict', generator() ]] ],
   ],
 )[0][1]
 

--- a/test/preamble.js
+++ b/test/preamble.js
@@ -15,7 +15,7 @@ const code = codeGen(
   {},
   { stringify: '../src/deserializer.js', deString: '../src/deserializer.js' },
   [
-    [ path.resolve(__dirname, 'preamble-output.js'), generator() ],
+    [ path.resolve(__dirname, 'preamble-output.js'), [[ 'preamble', generator() ]] ],
   ],
 )[0][1]
 


### PR DESCRIPTION
The configuration has changed such that a module can export multiple generators, which in turn emit multiple refiners all within the same file.

Document an example of using `degenString`, and add documentation for creating a custom generator.

This configuration change is breaking!