### PR TITLE
fix strict fix

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,13 @@
 *** Breaking
 *** Additions
 *** Fixes
+    + Fix an issue where =flow-degen= could no longer be recognized as an
+      imported module by Flow. This is related to recent changes to make
+      =flow-degen= work when =strict= is enabled. It is not well understood what
+      role =strict= played to cause a problem with the library, but it is
+      suspected to be a difference in Flow versions. The old =./index.js.flow=
+      workaround has been restored, yet we still retain the original =strict=
+      fix.
 ** 0.12.0
 *** Breaking
 *** Additions

--- a/flow-dist.sh
+++ b/flow-dist.sh
@@ -1,17 +1,34 @@
 #! /usr/bin/env bash
 
 set -e
-# TODO: Link Flow github issue that shows how this workaround works.
+# This file transpiles the src directory into dist, but also provides Flow
+# typings as part of the package. See
+# https://github.com/facebook/flow/issues/1996#issuecomment-228925018 for
+# background on this workaround.
 
 rm -rf dist
 mkdir -p dist
 
 yarn babel -d dist/ src/*
 
+# This was added to work around an issue with Flow strict. The cause is not well
+# understood and this doesn't seem to fix all cases of using Flow's stirct mode.
+# Furthermore, it breaks projects that do not use Flow strict. The root
+# ./index.js.flow workaround (see below) fixes the problem. These fixes can
+# coexist.
 cp src/index.js dist/index.js.flow
+# When doing import {...} from 'flow-degen', Flow looks at the root directory
+# first, and finds index.js.flow. It's just a copy of our original src/index.js,
+# but the paths have been renamed to look into our src directory, which hasn't
+# been transformed by babel yet. Since the .flow file is recognizable only by
+# Flow, Flow will follow this import chain into the src directory where it can
+# pick up more types from the untransformed code. The runtime import chain will
+# still follow into the dist directory as intended.
+cp src/index.js index.js.flow
 cp src/config.deserializer.js dist/config.deserializer.js.flow
 cp src/base-gen.js dist/base-gen.js.flow
 
+sed -i 's@\./@./src/@' index.js.flow
 sed -i 's@\./@../src/@' dist/index.js.flow
 sed -i 's@\./@../src/@' dist/config.deserializer.js.flow
 sed -i 's@\./@../src/@' dist/base-gen.js.flow

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,37 @@
+// @flow strict
+
+export {
+  deBool,
+  deField,
+  deList,
+  deMapping,
+  deNumber,
+  deString,
+  stringify,
+} from './src/deserializer.js'
+// export {
+//   codeGen,
+// } from './src/base-gen.js'
+export {
+  degenBool,
+  degenEnum,
+  degenField,
+  degenFilePath,
+  degenList,
+  degenNumber,
+  degenObject,
+  degenRefiner,
+  degenSentinelValue,
+  degenString,
+  degenSum,
+  degenType,
+  degenValue,
+  mergeDeps,
+} from './src/generator.js'
+export type {
+  CodeGenDep,
+  DeImport,
+  DeType,
+  DeserializerGenerator,
+  MetaType,
+} from './src/generator.js'


### PR DESCRIPTION
The strict fix applied earlier must have some other involved component, because
we've encountered projects that both use and don't use strict that the strict
fix seems to break. It is not well understood why or how switching to strict
mode breaks in some cases, and it is also not understood what those exact cases
are, but is not enough to simply be strict. This change brings back the original
index.js.flow workaround that lives in the root directory, and also retains the
original strict fix (because that fixed _something_).

Once we have more understanding we should record that somewhere.

Copious amounts of comments have been added to speak of what fixes are used
where and why. The Flow ticket that includes the index.js.flow workaround has
also been linked as well, per the original TODO.

CC @gyrfalcon due to the original strict fix.