### PR TITLE
Add Degen Function For Maybe Types

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -10,6 +10,8 @@
 ** Upcoming
 *** Breaking
 *** Additions
+    + =degenMaybe= added to create refiners for maybe types (type Foo =
+      ?string).
 *** Fixes
 ** 0.13.0
 *** Breaking

--- a/README.org
+++ b/README.org
@@ -155,6 +155,49 @@ yarn add -E -D flow-degen
      A "mapping" is of the type ={[A]: B}= although usually it will be
      ={[string]: mixed}=. It takes a key deserializer and a value deserializer
      for =A= and =B= respectively.
+**** degenMaybe
+     The =degenMaybe= generator is for creating refiners for maybe types (e.g.
+     type Foo = ?string). The maybe type will still require additional
+     refinement after passing through the refiner. For example, given the type:
+
+     #+begin_src js
+       export type Foo = {
+         bar: ?string,
+       }
+     #+end_src
+
+     And generator:
+     #+begin_src js
+       import { degenObject, degenField, degenMaybe, degenString } from 'flow-degen'
+
+       const fooType = { name: 'Foo', typeParams: [] }
+       const stringType = { name: 'string', typeParams: [] }
+       export const fooGenerator = () => degenObject(fooType, [
+         degenField('bar', degenMaybe(stringType, degenString())),
+       ])
+     #+end_src
+
+     The refiner would be used like so:
+     #+begin_src js
+       import { deFoo } from './foo-refiner.js'
+
+       declare var someInput: mixed
+
+       const eitherResult = deFoo(someInput)
+
+       if(eitherResult instanceof Error) {
+         // Here the result did not refine correctly.
+         console.error('How did this happen?', eitherResult)
+       } else {
+         // We have a foo, but bar may not have been present
+         if (eitherResult.bar != null) {
+           console.log(eitherResult.bar + ' was refined')
+         } else {
+           console.log('result had a null bar')
+         }
+       }
+     #+end_src
+
 **** degenNumber
      The =degenNumber= deserializer simply deserializes a value as a =number=.
 **** degenObject

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {},
   "scripts": {
     "generate-config": "yarn babel-node flow-degen meta-config.json",
-    "test": "yarn babel-node test/exhaustive-union.js && yarn babel-node test/flow-strict.js && yarn babel-node test/preamble.js && yarn babel-node test/imports.js && yarn babel-node test/base-path.js"
+    "test": "yarn babel-node test/test-suite.js"
   }
 }

--- a/src/generator.js
+++ b/src/generator.js
@@ -365,3 +365,27 @@ export const degenRefiner = <CustomType: string, CustomImport: string>(
     { types: [], imports: [refinerSymbol], hoists: [] },
   ]
 }
+
+export const degenMaybe = <CustomType: string, CustomImport: string>(
+  refinerType: MetaType<CustomType, CustomImport>,
+  refiner: DeserializerGenerator<CustomType, CustomImport>,
+): DeserializerGenerator<CustomType, CustomImport> => {
+  const [code, dependencies] = refiner
+
+  return [
+    () => {
+      return `
+        (x: mixed): ?${refinerType.name} | Error => {
+          if (x != null) {
+            const refiner = ${code()}
+
+            return refiner(x)
+          } else {
+            return null
+          }
+        }
+      `
+    },
+    mergeDeps(dependencies, { types: [ refinerType ], imports: [], hoists: [] }),
+  ]
+}

--- a/src/generator.js
+++ b/src/generator.js
@@ -375,7 +375,7 @@ export const degenMaybe = <CustomType: string, CustomImport: string>(
   return [
     () => {
       return `
-        (x: mixed): ?${refinerType.name} | Error => {
+        (x: mixed): ?${typeHeader(refinerType)} | Error => {
           if (x != null) {
             const refiner = ${code()}
 

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -2,28 +2,46 @@
 import assert from 'assert'
 import path from 'path'
 import {
+  degenField,
   degenMaybe,
+  degenObject,
   degenString,
 } from '../src/generator.js'
 import { runFlow } from './utils.js'
 import { codeGen } from '../src/base-gen.js'
 
+export type ParamType<T: string> = {
+  foo: T,
+}
+
 const stringType = { name: 'string', typeParams: [] }
+const paramTypeType = { name: 'ParamType', typeParams: [ stringType ] }
 
 const maybeStringGenerator = () => degenMaybe(stringType, degenString())
-
-const maybeStringOutputFile = path.resolve(__dirname, 'maybe-output.js')
+const paramTypeGenerator = () => degenMaybe(paramTypeType, degenObject(
+  paramTypeType,
+  [
+    degenField('foo', degenString()),
+  ],
+))
 
 const code = codeGen(
   __dirname,
   '',
   {
+    'ParamType': __filename,
   },
   {
+    deField: '../src/deserializer.js',
     deString: '../src/deserializer.js',
   },
   [
-    [ path.resolve(__dirname, 'maybe-output.js'), [[ 'maybeStringRefiner', maybeStringGenerator() ]] ],
+    [
+      path.resolve(__dirname, 'maybe-output.js'), [
+        [ 'maybeStringRefiner', maybeStringGenerator() ],
+        [ 'paramTypeRefiner', paramTypeGenerator() ],
+      ],
+    ],
   ],
 )[0][1]
 

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -1,0 +1,38 @@
+// @flow strict
+import assert from 'assert'
+import path from 'path'
+import {
+  degenMaybe,
+  degenString,
+} from '../src/generator.js'
+import { runFlow } from './utils.js'
+import { codeGen } from '../src/base-gen.js'
+
+const stringType = { name: 'string', typeParams: [] }
+
+const maybeStringGenerator = () => degenMaybe(stringType, degenString())
+
+const maybeStringOutputFile = path.resolve(__dirname, 'maybe-output.js')
+
+const code = codeGen(
+  __dirname,
+  '',
+  {
+  },
+  {
+    deString: '../src/deserializer.js',
+  },
+  [
+    [ path.resolve(__dirname, 'maybe-output.js'), [[ 'maybeStringRefiner', maybeStringGenerator() ]] ],
+  ],
+)[0][1]
+
+runFlow(code).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { exec } from 'child_process'
+
+const runTest = (testFile: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const process = exec(`yarn babel-node test/${testFile}`, {}, (error, stdout, sterr) => {
+      if (error) {
+        console.error('Error running test', testFile, stdout.toString())
+        reject(new Error('test exit code: ' + String(error.code)))
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+Promise.all([
+  runTest('base-path.js'),
+  runTest('exhaustive-union.js'),
+  runTest('flow-strict.js'),
+  runTest('imports.js'),
+  runTest('maybe.js'),
+  runTest('preamble.js'),
+]).then(() => {
+  console.log('All tests passed!')
+  process.exit(0)
+}).catch(() => {
+  console.error('There were failing tests! Check the console output for details.')
+  process.exit(1)
+})


### PR DESCRIPTION
Adds a degenMaybe function to generate refiners for maybe types (this
only covers maybe types, optional fields/parameters won't be handled by
this addition). Also adds a simple test harness for running the tests
rather than having to add new tests to the test script in package.json.