### PR TITLE
add explicit typing at call sites to reduce inferencing

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,11 @@
 *** Breaking
 *** Additions
 *** Fixes
+    1. Reduce the amount of type inferencing =flow-degen= relies upon. Consumers
+       can easily run into a "recursion limit exceeded" issue with Flow. To work
+       around this, some functions have been made to specifically indicate their
+       type parameters at the call sites. This has been shown to fix the
+       problem, but it is difficult to build tests towards.
 ** 0.14.0
 *** Breaking
 *** Additions

--- a/src/base-gen.js
+++ b/src/base-gen.js
@@ -38,7 +38,7 @@ const baseImportLocations: {[import: DeImport]: string} = {
   stringify: 'flow-degen',
 }
 
-const globalTypes = [
+const globalTypes: $ReadOnlyArray<DeType> = [
   'bool',
   'boolean',
   'function',
@@ -49,7 +49,7 @@ const globalTypes = [
 
 // Use this to convert types to a series of file paths.
 // type StringMap<T: string> = {[key: T]: string}
-type KeyedLists = {[key: string]: Array<string>}
+type KeyedLists = {[key: string]: $ReadOnlyArray<string>}
 
 const uniqueFromLookup = (
   lookup: {[string]: string},
@@ -89,7 +89,10 @@ const addJavascriptImports = <T: string>(
   importKeyword: string,
   imports: $ReadOnlyArray<string>,
 ): string => {
-  const locationsWithImports = reduce(
+  const locationsWithImports = reduce<
+      {[string]: $ReadOnlyArray<string>},
+      string,
+    >(
     partial(uniqueFromLookup, [ locations, globalsToIgnore ]),
     {},
     imports
@@ -175,7 +178,9 @@ export const codeGen = <CustomType: string, CustomImport: string>(
           return [`export const ${name} = ` + fn(), deps]
         })
       const code = codeAndDeps.map(([code, ]) => code).join('\n')
-      const deps = codeAndDeps.map(([, deps]) => deps).reduce(mergeDeps, {
+      const deps = codeAndDeps.map(([, deps]) => deps).reduce<
+          CodeGenDep<CustomType, CustomImport>,
+        >(mergeDeps, {
         hoists: [],
         imports: [],
         types: [],
@@ -205,7 +210,10 @@ export const fileGen = <CustomType: string, CustomImport: string>(
   preamble: string,
   typeLocations: {[type: CustomType]: string},
   customImportLocations: {[type: CustomImport]: string},
-  generators: Array<[string, Array<[ string, DeserializerGenerator<CustomType, CustomImport>]>]>,
+  generators: Array<[
+    string,
+    Array<[ string, DeserializerGenerator<CustomType, CustomImport>]>,
+  ]>,
 ) => {
   return Promise.all(
     codeGen(baseDir, preamble, typeLocations, customImportLocations, generators)


### PR DESCRIPTION
While very handy, Flow's type inferencing has a notable performance impact, and
if the inferencing is done too much a consumer can run into a "recursion limit
exceeded" error.

There should be no runtime impact to both flow-degen itself and the refiners it
emits.

I'm not sure what kinds of tests we could write for these since producing the error isn't well understood in the first place. It has been tested in a consuming project that had the error, and these changes have been verified to fix the issue.