### PR TITLE
add contributing guide and code-of-conduct

### DIFF
--- a/CODE_OF_CONDUCT.org
+++ b/CODE_OF_CONDUCT.org
@@ -1,0 +1,134 @@
+#+title:     Code of Conduct
+#+author:    Logan Barnett
+#+email:     logustus@gmail.com
+#+date:      <2019-09-29 Sun>
+#+language:  en
+#+file_tags:
+#+tags:
+
+* code of conduct
+** short version
+   Shorter version =flow-degen= is dedicated to providing a harassment-free
+   experience for everyone, regardless of gender, gender identity and
+   expression, sexual orientation, disability, physical appearance, body size,
+   age, race, or religion. We do not tolerate harassment of participants in any
+   form.
+
+   This code of conduct applies to all =flow-degen= spaces, including [list, eg
+   "our mailing lists and IRC channel"], both online and off. Anyone who
+   violates this code of conduct may be sanctioned or expelled from these spaces
+   at the discretion of the [[code of conduct enforcers]].
+
+   Some =flow-degen= spaces may have additional rules in place, which will be
+   made clearly available to participants. Participants are responsible for
+   knowing and abiding by these rules.
+
+** long version
+   =flow-degen= is dedicated to providing a harassment-free experience for
+   everyone. We do not tolerate harassment of participants in any form.
+
+   This code of conduct applies to all =flow-degen= spaces, including
+   =flow-degen='s github project and future spaces maintained by the
+   =flow-degen= primary maintainers, both online and off. Anyone who violates
+   this code of conduct may be sanctioned or expelled from these spaces at the
+   discretion of the [[code of conduct enforcers]].
+
+   Some =flow-degen= spaces may have additional rules in place, which will be
+   made clearly available to participants. Participants are responsible for
+   knowing and abiding by these rules.
+
+   Harassment includes:
+
+   + Offensive comments related to gender, gender identity and expression,
+     sexual orientation, disability, mental illness, neuro(a)typicality,
+     physical appearance, body size, age, race, or religion.
+
+   + Unwelcome comments regarding a person’s lifestyle choices and practices,
+     including those related to food, health, parenting, drugs, and employment.
+   + Deliberate misgendering or use of ‘dead’ or rejected names.
+   + Gratuitous or off-topic sexual images or behaviour in spaces where they’re
+     not appropriate.
+   + Physical contact and simulated physical contact (eg, textual descriptions
+     like “*hug*” or “*backrub*”) without consent or after a request to stop.
+   + Threats of violence.
+   + Incitement of violence towards any individual, including encouraging a
+     person to commit suicide or to engage in self-harm.
+   + Deliberate intimidation.
+   + Stalking or following.
+   + Harassing photography or recording, including logging online activity for
+     harassment purposes.
+   + Sustained disruption of discussion.
+   + Unwelcome sexual attention.
+   + Pattern of inappropriate social contact, such as requesting/assuming
+     inappropriate levels of intimacy with others
+   + Continued one-on-one communication after requests to cease.
+   + Deliberate “outing” of any aspect of a person’s identity without their
+     consent except as necessary to protect vulnerable people from intentional
+     abuse.
+   + Publication of non-harassing private communication.
+
+   =flow-degen= prioritizes marginalized people’s safety over privileged
+   people’s comfort. [[code of conduct enforcers]] reserves the right not to act on
+   complaints regarding:
+
+   + ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and
+     ‘cisphobia’
+   + Reasonable communication of boundaries, such as “leave me alone,” “go
+     away,” or “I’m not discussing this with you.”
+   + Communicating in a ‘tone’ you don’t find congenial
+   + Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or
+     assumptions
+
+   Reporting
+
+   If you are being harassed by a member of =flow-degen=, notice that someone
+   else is being harassed, or have any other concerns, please contact the [[code
+   of conduct enforcers]] at [[mailto://logustus@gmail.com][logustus@gmail.com]]. If the person who is harassing
+   you is on the team, they will recuse themselves from handling your incident.
+   We will respond as promptly as we can.
+
+   This code of conduct applies to =flow-degen= spaces, but if you are being
+   harassed by a member of =flow-degen= outside our spaces, we still want to
+   know about it. We will take all good-faith reports of harassment by
+   =flow-degen= members, especially =flow-degen= collaborators, seriously. This
+   includes harassment outside our spaces and harassment that took place at any
+   point in time. The abuse team reserves the right to exclude people from
+   =flow-degen= based on their past behavior, including behavior outside
+   =flow-degen= spaces and behavior towards people who are not in =flow-degen=.
+
+   In order to protect volunteers from abuse and burnout, we reserve the right
+   to reject any report we believe to have been made in bad faith. Reports
+   intended to silence legitimate criticism may be deleted without response.
+
+   We will respect confidentiality requests for the purpose of protecting
+   victims of abuse. At our discretion, we may publicly name a person about whom
+   we’ve received harassment complaints, or privately warn third parties about
+   them, if we believe that doing so will increase the safety of =flow-degen=
+   members or the general public. We will not name harassment victims without
+   their affirmative consent.
+
+   Consequences
+
+   Participants asked to stop any harassing behavior are expected to comply
+   immediately.
+
+   If a participant engages in harassing behavior, [[code of conduct enforcers]] may
+   take any action they deem appropriate, up to and including expulsion from all
+   =flow-degen= spaces and identification of the participant as a harasser to
+   other =flow-degen= members or the general public.
+
+** code of conduct enforcers
+   The following members have committed to enforcing the [[code of conduct]]:
+
+   + [[mailto://logustus@gmail.com][Logan Barnett]] - @LoganBarnett (github).
+
+** attributions
+   This code of conduct was lifted almost verbatim from [[http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy][Geek Feminism's sample
+   community Code of Conduct]] as of [2019-09-29 Sun], which was created by the
+   Geek Feminism community. Formatting changes have been applied to make it fit
+   in into an idiomatic =org-mode= file, and substitutions have been made to
+   speak with the voice of =flow-degen= per the adlib suggestions of the
+   original document. This is not a promise that we will keep current with
+   changes to the original code of conduct, but =flow-degen= will strive to
+   maintain a safe and welcoming community to anyone that does not undermine
+   that safety.

--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -1,0 +1,75 @@
+#+title:     CONTRIBUTING
+#+author:    Logan Barnett
+#+email:     logustus@gmail.com
+#+date:      <2018-05-11 Fri>
+#+language:  en
+#+file_tags: readme
+
+* code of conduct
+  Make sure to have a familiarity with the [[file:./CODE_OF_CONDUCT.org][code of conduct]] for this project.
+  Failure to do so does not exempt behavior.
+
+* writing code
+  While none of these are hard rules in building a pull request, trying to keep
+  in spirit of them as much as reasonably possible will ensure the smoothest
+  path to getting your pull request merged.
+** ensure the pull request is desired
+   Adding clarification and examples to documentation is an example of changes
+   that are generally welcome at any time. Adding UI components to =flow-degen=
+   wouldn't be a desirable change to the project though. Use your judgment when
+   adding pull requests to save yourself some time. If you're not sure if the
+   change would be immediately welcome, consider opening a ticket in the issue
+   tracker as a means of starting discussion. Describe what problem you're
+   encountering and would like to solve with a pull request.
+
+** code formatting
+   This is a work in progress, but going forward there will be hooks in place
+   that cause edited files to be run through =prettier.js= to achieve desired
+   formatting as part of a commit hook. Do not bypass this hook without
+   justification in the code and the pull request description itself.
+
+** document surprises
+   Assume other readers of the code will have a basic familiarity of JavaScript,
+   Flow, and problem domain of =flow-degen=. Anything that is done that wouldn't
+   be obvious to the reader should be documented with a code comment, and
+   possibly called out in the pull request or even formal documentation (such as
+   the README).
+
+** document changes in the changelog
+   The [[file:./CHANGELOG.org][changelog]] has a list of old changes as well as upcoming ones. In the
+   "Upcoming" section you can describe the changes you made across the
+   categories listed there. Upon doing a release, all changes listed in
+   "Upcoming" will be moved to the release version, and a new "Upcoming" will be
+   built. Having your description of changes in "Upcoming" right from the start
+   ensures a smooth release process, and provides a human friendly means of
+   summarizing what has changed in a given version, and actions a consumer might
+   need to take on to account for your changes.
+
+** document any API changes/additions
+   As part of your pull request, you might need to change the API of a function,
+   or add new functions that are exposed to consumers. These changes should be
+   reflected in the documentation of the API (currently the README), with a
+   textual description along with an example.
+
+** provide an automated test for your changes
+   Generally we want to prove that your changes work, and future changes do not
+   break today's changes. As such we need automated tests to ensure the
+   functionality. The general guideline is that if we can remove the non-test
+   changes in your pull request and test suite still passes, your tests are
+   inadequate and need improvement. Some changes are difficult to write tests
+   for. We are eager to help put together tests with you, and sometimes tests
+   are nonsensical or impractical to put together. When in doubt about providing
+   tests, asking in the pull request or related ticket is the best course of
+   action.
+
+** don't commit dist
+   The =dist= directory is committed during the release process as a form of
+   transparency and a means of allowing consumption of the library outside of a
+   formal release on =npm=. While in practice any changes you commit to =dist=
+   will be overridden during the release process, we ask that you try not to
+   commit =dist=. In other projects this has been a means of attack, and it also
+   adds files that reviewers must ignore during the release process.
+
+   If you need to commit =dist= for your own testing/consumption purposes,
+   consider making a branch off of your pull request with the =-dist= suffix,
+   and consuming that branch.


### PR DESCRIPTION
I left just myself as an enforcer, but if other collaborators are interested in this I will happily add them.