### PR TITLE
add optional field support for degenObject

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -23,6 +23,7 @@
        code when running. This can be helpful when running tests and you want
        the generated output to display and a syntax error causes =prettier= to
        fail. This way you can still limp by and see the generated code.
+    3. =typeHeader= is now exported. Documentation to follow soon!
 *** Fixes
     1. Reduce the amount of type inferencing =flow-degen= relies upon. Consumers
        can easily run into a "recursion limit exceeded" issue with Flow. To work

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,7 +9,20 @@
 * changelog
 ** Upcoming
 *** Breaking
+    1. =degenObject= now takes a list of optional fields as a new argument at
+       the end of the argument list. The simplest thing to do is add =[]= as the
+       last parameter to your calls, and you will have the same behavior as
+       before.
+    2. =codeGen= takes a =prettify= flag as the second argument. Use =true= for
+       this argument to keep your original behavior.
 *** Additions
+    1. The =degenObject= generator now takes a list of optional fields so any
+       field that is an optional type (not necessarily a maybe type) can also be
+       supported by the system.
+    2. Consumers of =codeGen= may now indicate whether or not to prettify the
+       code when running. This can be helpful when running tests and you want
+       the generated output to display and a syntax error causes =prettier= to
+       fail. This way you can still limp by and see the generated code.
 *** Fixes
     1. Reduce the amount of type inferencing =flow-degen= relies upon. Consumers
        can easily run into a "recursion limit exceeded" issue with Flow. To work

--- a/README.org
+++ b/README.org
@@ -206,7 +206,51 @@ yarn add -E -D flow-degen
 **** degenObject
      An "Object" can be thought of as a collection of "fields". See =degenField=
      as these go together except for empty objects. =degenObject= takes the type
-     of the object and a list of fields that =degenField= can emit.
+     of the object and a list of required fields that =degenField= can emit, and
+     a second list of =degenField= results that represent the optional fields.
+
+     Assume the object =Cat=.
+
+     #+begin_src js
+
+       export type Cat = {
+         // Cats always have demands.
+         demands: number,
+         // Cats can have no love sometimes.
+         love?: number,
+       }
+
+       const catType = { name: 'Cat', typeParams: [] }
+       const catGenerator = () => degenObject(catType, [
+         degenField('demands', degenNumber()),
+       ], [
+         degenField('love', degenNumber()),
+       ])
+     #+end_src
+
+     It is well known that cats always have =demands= but only sometimes have
+     =love=. It is fallacious to assume =love= will always be present.
+
+     #+begin_src js
+       import { catRefiner } from './cat-refiner.js'
+
+       // It's pretty easy to get an unsanitized cat from anywhere, really.
+       handleUnsanitizedCat((input) => {
+         const catOrError: string | Error = catRefiner(input)
+         if(catOrError instanceof Error) {
+           goGetADog()
+         } else {
+           // We have a cat! But we can't expect love.
+           // Flow will also settle for a null check for love.
+           if(catOrError.hasOwnProperty('love')) {
+             console.log(`My cat loves me ${catOrError.love} love units!`)
+           } else {
+             console.log('My cat does not have any love for me at all...')
+           }
+         }
+       })
+     #+end_src
+
 **** degenString
      The =degenString= deserializer simply deserializes a value as a =string=.
 

--- a/flow-degen.js
+++ b/flow-degen.js
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
 // @flow strict
 
+import { typeof fileGen as FileGen } from './src/base-gen.js'
 const fs = require('fs')
 const path = require('path')
 // All of the files used here are transpiled, but this helps with consuming
@@ -20,10 +21,7 @@ require('@babel/register')(babelConfig)
 
 const R = require('ramda')
 
-// We can't really type check against these results. If we export fileGen as
-// part of the library's proper interface, we should be able to achieve type
-// safety again.
-const fileGen = require('./dist/base-gen.js').fileGen
+const fileGen: FileGen<string, string> = require('./dist/base-gen.js').fileGen
 const configDeserializer = require('./dist/config.deserializer.js').deConfig
 
 const configPath = process.argv[2]
@@ -63,6 +61,9 @@ else {
 
     fileGen(
       configFile.baseDir,
+      // TODO: Let's bundle this up into the config file and reduce the args
+      // here.
+      true,
       configFile.generatedPreamble,
       configFile.typeLocations,
       R.merge(

--- a/index.js.flow
+++ b/index.js.flow
@@ -28,6 +28,7 @@ export {
   degenType,
   degenValue,
   mergeDeps,
+  typeHeader,
 } from './src/generator.js'
 export type {
   CodeGenDep,

--- a/src/base-gen.js
+++ b/src/base-gen.js
@@ -163,6 +163,7 @@ const hoist = (hoists: Array<string>): string => {
 
 export const codeGen = <CustomType: string, CustomImport: string>(
   baseDir: string,
+  prettify: bool,
   preamble: string,
   typeLocations: {[type: CustomType]: string},
   customImportLocations: {[type: CustomImport]: string},
@@ -199,7 +200,7 @@ export const codeGen = <CustomType: string, CustomImport: string>(
       // console.error(finalCode)
       return [
         path.join(baseDir, file),
-        prettier.format(finalCode, prettierArgs),
+        prettify ? prettier.format(finalCode, prettierArgs) : finalCode,
         deps,
       ]
     })
@@ -207,6 +208,7 @@ export const codeGen = <CustomType: string, CustomImport: string>(
 
 export const fileGen = <CustomType: string, CustomImport: string>(
   baseDir: string,
+  prettify: bool,
   preamble: string,
   typeLocations: {[type: CustomType]: string},
   customImportLocations: {[type: CustomImport]: string},
@@ -216,7 +218,14 @@ export const fileGen = <CustomType: string, CustomImport: string>(
   ]>,
 ) => {
   return Promise.all(
-    codeGen(baseDir, preamble, typeLocations, customImportLocations, generators)
+    codeGen(
+      baseDir,
+      prettify,
+      preamble,
+      typeLocations,
+      customImportLocations,
+      generators,
+    )
       .map(([ file, code ]) => stringToFilePromise(file, code))
   )
   .then(() => {

--- a/src/config-generator.js
+++ b/src/config-generator.js
@@ -38,5 +38,5 @@ export const degenConfig = () => degenObject<string, string>(configType, [
     degenField('exports', degenMapping(degenString(), degenString())),
     degenField('inputFile', degenFilePath()),
     degenField('outputFile', degenFilePath()),
-  ]))),
-])
+  ], []))),
+], [])

--- a/src/generator.js
+++ b/src/generator.js
@@ -2,12 +2,14 @@
 import {
   append,
   concat,
+  length,
   map,
   merge,
   pipe,
   prop,
   reduce,
   tail,
+  times,
 } from 'ramda'
 
 import { stringify } from './deserializer.js'
@@ -113,9 +115,8 @@ if(${name} instanceof Error) {
 } else {
 `
     }).join('\n')}
-      const result: ${typeName} = {
-        ${requiredFieldNames.join(',\n')}
-      }
+      const result = {}
+        ${requiredFieldNames.map(f => `result.${f} = ${f}`).join('\n')}
       ${optionalFields.map(([name, refiner]) => {
         return `\
 if(json.hasOwnProperty('${name}')) {
@@ -128,8 +129,7 @@ if(json.hasOwnProperty('${name}')) {
 }`
       }).join('\n')}
       return result
-    ${tail(requiredFieldRefiners.map(() => '}')).join('')}
-    }
+    ${times(() => '}', length(requiredFieldRefiners)).join('')}
   }
 }
 `

--- a/src/generator.js
+++ b/src/generator.js
@@ -153,28 +153,6 @@ export const degenField = <CustomType: string, CustomImport: string>(
   ]]
 }
 
-
-export const degenOptionalField = <CustomType: string, CustomImport: string>(
-  fieldName: string,
-  deserializer: DeserializerGenerator<CustomType, CustomImport>,
-): FieldDeserializer<CustomType, CustomImport> => {
-  const [deserializerFn, deps] = deserializer
-  return [fieldName, [() => {
-    // the `else {` is terminated in deObject during the join.
-    return `const ${fieldName} = (
-      deField('${fieldName}',
-        (${deserializerFn()}),
-        json.${fieldName})
-    )
-if(${fieldName} instanceof Error) {
-  const error: Error = ${fieldName}
-  return new Error('Could not deserialize field "${fieldName}": ' + error.message)
-} else {`
-  },
-    mergeDeps(deps, { types: [], imports: ['deField'], hoists: [] }),
-  ]]
-}
-
 export const degenList = <CustomType: string, CustomImport: string>(
   element: DeserializerGenerator<CustomType, CustomImport>,
 ): DeserializerGenerator<CustomType, CustomImport> => {

--- a/test/base-path.js
+++ b/test/base-path.js
@@ -11,6 +11,7 @@ const generator = () => degenString()
 
 const result = codeGen(
   __dirname,
+  true,
   '',
   {
     'Foo': __filename,

--- a/test/custom-gen-with-import.js
+++ b/test/custom-gen-with-import.js
@@ -62,11 +62,12 @@ const fooType = { name: 'Foo', typeParams: [] }
 
 const generator = () => customDegen(
   fooType,
-  degenObject(fooType, [degenField('bar', degenString())]),
+  degenObject(fooType, [degenField('bar', degenString())], []),
 )
 
 const code = codeGen(
   __dirname,
+  true,
   '',
   {
     'Foo': __filename,

--- a/test/exhaustive-union.js
+++ b/test/exhaustive-union.js
@@ -50,20 +50,21 @@ const generator = () => degenSum(unionType, 'kind', unionKindType, [
   degenSentinelValue('foo', degenObject(fooType, [
     degenField('a', degenString()),
     degenField('kind', degenValue('string', 'foo')),
-  ])),
+  ], [])),
   degenSentinelValue('bar', degenObject(barType, [
     degenField('b', degenNumber()),
     degenField('kind', degenValue('string', 'bar')),
-  ])),
+  ], [])),
   // This is the value we expect to cause a failure.
   degenSentinelValue('baz', degenObject(bazType, [
     degenField('c', degenBool()),
     degenField('kind', degenValue('string', 'baz')),
-  ])),
+  ], [])),
 ])
 
 const code = codeGen(
   __dirname,
+  true,
   '',
   {
     'Union': __filename,

--- a/test/flow-strict.js
+++ b/test/flow-strict.js
@@ -10,6 +10,7 @@ const generator = () => degenString()
 
 const code = codeGen(
   __dirname,
+  true,
   '',
   {},
   { stringify: '../src/deserializer.js', deString: '../src/deserializer.js' },

--- a/test/imports.js
+++ b/test/imports.js
@@ -28,23 +28,24 @@ const barType = { name: 'Bar', typeParams: [] }
 const bazType = { name: 'Baz', typeParams: [] }
 
 const fooGenerator = () => degenObject(fooType, [
-    degenField('a', degenString()),
-  ])
+  degenField('a', degenString()),
+], [])
 
 const barGenerator = () => degenObject(barType, [
-    degenField('b', degenRefiner('deFoo')),
-    degenField('bb', degenRefiner('deBaz'))
-  ])
+  degenField('b', degenRefiner('deFoo')),
+  degenField('bb', degenRefiner('deBaz'))
+], [])
 
 const bazGenerator = () => degenObject(bazType, [
-    degenField('c', degenString()),
-  ])
+  degenField('c', degenString()),
+], [])
 
 const fooBarOutputFile = path.resolve(__dirname, 'foobar-imports-output.js')
 const bazOutputFile = path.resolve(__dirname, 'baz-imports-output.js')
 
 const code = codeGen(
   __dirname,
+  true,
   '',
   {
     "Foo": __filename,

--- a/test/merge-deps.js
+++ b/test/merge-deps.js
@@ -1,0 +1,34 @@
+// @flow strict
+import {
+  mergeDeps,
+  type DeserializerGenerator,
+  type MetaType,
+  typeHeader,
+} from '../src/generator.js'
+
+type MyImport =
+  | 'importedFn'
+  | 'otherIdentifier'
+
+const customDegen = <CustomType: string>(
+  refinerType: MetaType<CustomType, MyImport>,
+  refinerGenerator: DeserializerGenerator<CustomType, MyImport>,
+) => {
+  const [refinerCode, deps] = refinerGenerator
+  const header = typeHeader(refinerType)
+
+  return [
+    () => {
+      return `
+        (x: mixed): ${header} | Error => {
+          const refiner = ${refinerCode()}
+          return refiner(${refinerCode()}())
+        }
+      `
+    },
+    mergeDeps<CustomType, MyImport>(
+      deps,
+      { types: [], imports: [ 'importedFn' ], hoists: [] },
+    ),
+  ]
+}

--- a/test/object-optional-fields.js
+++ b/test/object-optional-fields.js
@@ -1,47 +1,44 @@
 // @flow strict
+
 import assert from 'assert'
 import path from 'path'
 import {
   degenField,
-  degenMaybe,
+  degenNumber,
   degenObject,
   degenString,
 } from '../src/generator.js'
 import { runFlow } from './utils.js'
 import { codeGen } from '../src/base-gen.js'
 
-export type ParamType<T: string> = {
-  foo: T,
+export type Obj = {
+  required: string,
+  optional?: number,
 }
 
-const stringType = { name: 'string', typeParams: [] }
-const paramTypeType = { name: 'ParamType', typeParams: [ stringType ] }
-
-const maybeStringGenerator = () => degenMaybe(stringType, degenString())
-const paramTypeGenerator = () => degenMaybe(paramTypeType, degenObject(
-  paramTypeType,
-  [
-    degenField('foo', degenString()),
-  ],
-  [],
-))
+const objType = { name: 'Obj', typeParams: [] }
+const objGenerator = () => degenObject(objType, [
+  degenField('required', degenString()),
+], [
+  degenField('optional', degenNumber()),
+])
 
 const code = codeGen(
   __dirname,
   true,
   '',
   {
-    'ParamType': __filename,
+    'Obj': __filename,
   },
   {
     deField: '../src/deserializer.js',
+    deNumber: '../src/deserializer.js',
     deString: '../src/deserializer.js',
   },
   [
     [
-      path.resolve(__dirname, 'maybe-output.js'), [
-        [ 'maybeStringRefiner', maybeStringGenerator() ],
-        [ 'paramTypeRefiner', paramTypeGenerator() ],
+      path.resolve(__dirname, 'object-optional-fields-output.js'), [
+        [ 'objRefiner', objGenerator() ],
       ],
     ],
   ],

--- a/test/object-optional-fields.js
+++ b/test/object-optional-fields.js
@@ -11,24 +11,24 @@ import {
 import { runFlow } from './utils.js'
 import { codeGen } from '../src/base-gen.js'
 
-export type Obj = {
+export type MixedObj = {
   required: string,
   optional?: number,
 }
 
-const objType = { name: 'Obj', typeParams: [] }
-const objGenerator = () => degenObject(objType, [
+const mixedObjType = { name: 'MixedObj', typeParams: [] }
+const mixedObjGenerator = () => degenObject(mixedObjType, [
   degenField('required', degenString()),
 ], [
   degenField('optional', degenNumber()),
 ])
 
-const code = codeGen(
+const codeWithRequired = codeGen(
   __dirname,
   true,
   '',
   {
-    'Obj': __filename,
+    'MixedObj': __filename,
   },
   {
     deField: '../src/deserializer.js',
@@ -38,13 +38,56 @@ const code = codeGen(
   [
     [
       path.resolve(__dirname, 'object-optional-fields-output.js'), [
-        [ 'objRefiner', objGenerator() ],
+        [ 'mixedObjRefiner', mixedObjGenerator() ],
       ],
     ],
   ],
 )[0][1]
 
-runFlow(code).then((errorText) => {
+runFlow(codeWithRequired).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})
+
+export type OptionalObj = {
+  optional?: number,
+  optionalAlso?: string,
+}
+
+const optionalObjType = { name: 'OptionalObj', typeParams: [] }
+const optionalObjGenerator = () => degenObject(optionalObjType, [
+], [
+  degenField('optional', degenNumber()),
+  degenField('optionalALso', degenString()),
+])
+
+const codeSansRequired = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'OptionalObj': __filename,
+  },
+  {
+    deField: '../src/deserializer.js',
+    deNumber: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+  },
+  [
+    [
+      path.resolve(__dirname, 'object-optional-fields-output.js'), [
+        [ 'optionalObjRefiner', optionalObjGenerator() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(codeSansRequired).then((errorText) => {
   assert.ok(
     errorText.match(/No errors!/),
     'Expected no errors in flow check but got errors:' + errorText,

--- a/test/preamble.js
+++ b/test/preamble.js
@@ -11,6 +11,7 @@ const generator = () => degenString()
 
 const code = codeGen(
   __dirname,
+  true,
   '/* Preamble */',
   {},
   { stringify: '../src/deserializer.js', deString: '../src/deserializer.js' },

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -12,15 +12,22 @@ import {
 
 const runTest = (testFile: string): Promise<void> => {
   return new Promise((resolve, reject) => {
-    const process = exec(`yarn babel-node test/${testFile}`, {}, (error, stdout, stderr) => {
-      console.log(`Running test ${testFile}`)
-      if (error) {
-        console.error('Error running test', testFile, stderr.toString())
-        reject(new Error('test exit code: ' + String(error.code)))
-      } else {
-        resolve()
-      }
-    })
+    const process = exec(
+      `yarn babel-node test/${testFile}`,
+      {},
+      (error, stdout, stderr) => {
+        if (error) {
+          console.error(
+            'Error running test',
+            testFile,
+            stdout.toString(),
+            stderr.toString(),
+          )
+          reject(new Error('test exit code: ' + String(error.code)))
+        } else {
+          resolve()
+        }
+      })
   })
 }
 
@@ -32,6 +39,7 @@ const tests = [
   'flow-strict.js',
   'imports.js',
   'maybe.js',
+  'object-optional-fields.js',
   'preamble.js',
 ]
 
@@ -50,7 +58,10 @@ const testPromises = pipe(
 Promise.all(testPromises(selectedTests)).then(() => {
   console.log('All tests passed!')
   process.exit(0)
-}).catch(() => {
-  console.error('There were failing tests! Check the console output for details.')
+}).catch((error: mixed) => {
+  console.error(
+    'There were failing tests! Check the console output for details.',
+    error,
+  )
   process.exit(1)
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -15,7 +15,7 @@ export const runFlow = (code: string): Promise<string> => {
   return new Promise((resolve, reject) => {
     const process = exec(`yarn flow check-contents`, {}, (error, stdout, sterr) => {
       if(error) {
-        // console.error('Error running "yarn flow check-contents":', error, stdout.toString())
+        console.error('Error running "yarn flow check-contents":', error, stdout.toString())
       } else {
         // console.log('is this the entire output?', stdout.toString())
       }


### PR DESCRIPTION
There's a few breaking changes in here. `degenObject` now requires, ironically, a list of optional fields. `codeGen` has added a parameter for easier debugging that disables `prettier` so you can still debug the generated output even with a syntax error. Any functions depending on `codeGen` will also need to supply or chain along the value.