### PR TITLE
Custom Generator Documentation and Testing Improvements

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,7 +22,7 @@ Pros:
 Cons:
 1. =flow-degen= does not currently provide a list of deserializer errors, but
    instead bails on the first error.
-3. There is potentially a memory/storage footprint concern for non-trivial sizes
+2. There is potentially a memory/storage footprint concern for non-trivial sizes
    and amounts of deserializers. A minifier may significantly mitigate this con.
    Using =degenRefiner= to reference other refiners can also reduce the
    footprint by calling other refiners instead of duplicating refinement logic

--- a/README.org
+++ b/README.org
@@ -22,8 +22,11 @@ Pros:
 Cons:
 1. =flow-degen= does not currently provide a list of deserializer errors, but
    instead bails on the first error.
-2. There is potentially a memory/storage footprint concern for non-trivial sizes
+3. There is potentially a memory/storage footprint concern for non-trivial sizes
    and amounts of deserializers. A minifier may significantly mitigate this con.
+   Using =degenRefiner= to reference other refiners can also reduce the
+   footprint by calling other refiners instead of duplicating refinement logic
+   in multiple places.
 
 ** installation
 
@@ -274,7 +277,7 @@ yarn add -E -D flow-degen
 
        const barType = { name: 'Bar', typeParams: [] }
        export const fooGenerator = () => degenObject(barType, [
-         degenField('foo', 'deFoo'),
+         degenField('foo', degenRefiner('deFoo')),
        ])
      #+end_src
 
@@ -294,14 +297,22 @@ yarn add -E -D flow-degen
       CustomImport: string>=, which is a tuple of a function that returns a
       =string= (the code) and a =CodeGenDep<CustomType: string, CustomImport:
       string>=. The exacts of these types can be found in =./src/generator.js=.
-    + The function that returns a string must accept a =mixed= as a parameter.
+    + The code returned by the function must accept a =mixed= as a parameter.
       This is your input provided from your mystery variable. It is assumed to
       be "deserialized" already in the sense that it is not a string of JSON but
       perhaps the result of =JSON.parse=.
     + If any imports are used, they must be enumerated in the =imports= list of
-      the =CodeGenDep=.
+      the =CodeGenDep=. Any imports used by the generated function will also
+      need to be part of the =CustomImport= type parameter of the generator as
+      well as included in =importLocations= in your =flow-degen=
+      configuration file (adding an import to =importLocations= is not necessary
+      if the import is an export from a refiner defined in your =flow-degen=
+      config).
     + If any type imports are used, they must be enumerated in the =types= list
-      of the =CodeGenDep=.
+      of the =CodeGenDep=. Any types used by the generated function will also
+      need to be part of the =CustomType= type parameter of the generator as
+      well as included in =typeLocations= in your =flow-degen= configuration
+      file.
     + Consider that your generated code could likely be embedded deep within a
       function chain. If you need some "root" access to the module to declare
       things such as throw-away types, use the =hoists= list to place code.
@@ -321,29 +332,49 @@ yarn add -E -D flow-degen
         mergeDeps,
         type DeserializerGenerator,
       } from 'flow-degen'
-      import { uppercase } from './my-string-utils.js'
+      import {
+        type UppercaseString,
+        uppercase,
+      } from './my-string-utils.js'
 
-      export const degenUppercaseString = <CustomType: string, CustomImport: string>(
-      ): DeserializerGenerator<CustomType, CustomImport> => {
+      type UppercaseGeneratorType =
+        | 'UppercaseString'
+
+      type UppercaseGeneratorImport =
+        | 'uppercase'
+
+      export const degenUppercaseString = (
+      ): DeserializerGenerator<UppercaseGeneratorType, UppercaseGeneratorImport> => {
         const [ stringGenerator, stringDeps ] = degenString()
         return [
-          `(x: mixed): string => {
-             return uppercase(${stringGenerator})
-          }`,
+          () => {
+            return `(x: mixed): UppercaseString => {
+               return uppercase(${stringGenerator()})
+            }`
+          },
           mergeDeps(
             stringDeps,
             {
               hoists: [],
               imports: [ 'uppercase' ],
-              types: [],
+              types: [ { name: 'UppercaseString', typeParams: [] } ],
             },
           ),
         ]
       }
     #+end_src
 
-    Custom generators are no different from the built-in generators. The
-    built-in generators in =src/generators.js= can be used as more complex
+    Custom generators are no different from the built-in generators.
+
+    #+begin_src js
+      import {
+        degenUppercaseString,
+      } from './custom-degens.js'
+
+      export const generateUppercaseStringRefiner = () => degenUppercaseString()
+    #+end_src
+
+    The built-in generators in =src/generators.js= can be used as more complex
     examples for building your own generators.
 
 *** command line
@@ -356,12 +387,13 @@ yarn flow-degen degen-config.json
 
 *** consuming generated deserializers
 
-The output files you indicate will always export a function as the =default=
-export. The function takes the form of =(mixed) => T | Error=.
+The output files you indicate will export refiner functions defined in the
+=exports= config for the generator. The refiner functions take the form of
+=(mixed) => T | Error=.
 
 #+begin_src javascript
 import fs from 'fs'
-import fooDeserializer from './foo.deserializer.js'
+import { fooDeserializer } from './foo.deserializer.js'
 
 const unvalidatedFoo = JSON.parse(fs.readFileSync('foo.json', 'utf8'))
 const fooOrError = fooDeserializer(unvalidatedFoo)

--- a/src/generator.js
+++ b/src/generator.js
@@ -310,7 +310,7 @@ const ${fnName} = (x: mixed): ${typeHeader} | Error => {
   )))]
 }
 
-const typeHeader = <CustomType: string, CustomImport: string>(
+export const typeHeader = <CustomType: string, CustomImport: string>(
   type: MetaType<CustomType, CustomImport>,
 ): string => {
   if(type.typeParams.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export {
   degenType,
   degenValue,
   mergeDeps,
+  typeHeader,
 } from './generator.js'
 export type {
   CodeGenDep,

--- a/test/custom-gen-with-import.js
+++ b/test/custom-gen-with-import.js
@@ -78,7 +78,7 @@ const code = codeGen(
   },
   [
     [
-      path.resolve(__dirname, 'custom-import-output.js'), [
+      path.resolve(__dirname, 'custom-gen-with-import-output.js'), [
         [ 'refine', generator() ],
       ],
     ],

--- a/test/custom-import.js
+++ b/test/custom-import.js
@@ -1,0 +1,85 @@
+// @flow strict
+import assert from 'assert'
+import path from 'path'
+import {
+  type DeserializerGenerator,
+  type MetaType,
+  degenField,
+  degenObject,
+  degenString,
+  mergeDeps,
+  typeHeader,
+} from '../src/index.js'
+import { runFlow } from './utils.js'
+import { codeGen } from '../src/base-gen.js'
+
+export type Foo = {
+  bar: string,
+}
+
+export const importedFn = (): Foo => {
+   return {
+     bar: 'default'
+   }
+ }
+
+const customDegen = <CustomType: string, CustomImport: string>(
+  refinerType: MetaType<CustomType, CustomImport>,
+  refinerGenerator: DeserializerGenerator<CustomType, CustomImport>,
+) => {
+  const [refinerCode, deps] = refinerGenerator
+  const header = typeHeader(refinerType)
+
+  return [
+    () => {
+      return `
+        (x: mixed): ${header} | Error => {
+          const refiner = ${refinerCode()}
+          return refiner(importedFn())
+        }
+      `
+    },
+    mergeDeps<CustomType, CustomImport>(
+      deps,
+      { types: [], imports: ['importedFn'], hoists: [] },
+    ),
+  ]
+}
+
+const stringType = { name: 'string', typeParams: [] }
+const fooType = { name: 'Foo', typeParams: [] }
+
+const generator = () => customDegen<string, string>(
+  fooType,
+  degenObject(fooType, [degenField('bar', degenString())]),
+)
+
+const code = codeGen(
+  __dirname,
+  '',
+  {
+    'Foo': __filename,
+  },
+  {
+    deField: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+    importedFn: __filename,
+  },
+  [
+    [
+      path.resolve(__dirname, 'custom-import-output.js'), [
+        [ 'refine', generator() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(code).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})

--- a/test/custom-import.js
+++ b/test/custom-import.js
@@ -2,6 +2,7 @@
 import assert from 'assert'
 import path from 'path'
 import {
+  type DeImport,
   type DeserializerGenerator,
   type MetaType,
   degenField,
@@ -23,9 +24,19 @@ export const importedFn = (): Foo => {
    }
  }
 
-const customDegen = <CustomType: string, CustomImport: string>(
-  refinerType: MetaType<CustomType, CustomImport>,
-  refinerGenerator: DeserializerGenerator<CustomType, CustomImport>,
+type CustomImportTestType =
+  | 'Foo'
+
+type CustomImportTestImport =
+  | 'importedFn'
+  // adding DeImport to the union shouldn't be necessary (and wasn't necessary
+  // in the real implementation this was adapted from), but flow isn't
+  // recognizing deField and deString on lines 75 and 76 otherwise
+  | DeImport
+
+const customDegen = (
+  refinerType: MetaType<CustomImportTestType, CustomImportTestImport>,
+  refinerGenerator: DeserializerGenerator<CustomImportTestType, CustomImportTestImport>,
 ) => {
   const [refinerCode, deps] = refinerGenerator
   const header = typeHeader(refinerType)
@@ -39,7 +50,7 @@ const customDegen = <CustomType: string, CustomImport: string>(
         }
       `
     },
-    mergeDeps<CustomType, CustomImport>(
+    mergeDeps<CustomImportTestType, CustomImportTestImport>(
       deps,
       { types: [], imports: ['importedFn'], hoists: [] },
     ),
@@ -49,7 +60,7 @@ const customDegen = <CustomType: string, CustomImport: string>(
 const stringType = { name: 'string', typeParams: [] }
 const fooType = { name: 'Foo', typeParams: [] }
 
-const generator = () => customDegen<string, string>(
+const generator = () => customDegen(
   fooType,
   degenObject(fooType, [degenField('bar', degenString())]),
 )

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -12,10 +12,10 @@ import {
 
 const runTest = (testFile: string): Promise<void> => {
   return new Promise((resolve, reject) => {
-    const process = exec(`yarn babel-node test/${testFile}`, {}, (error, stdout, sterr) => {
+    const process = exec(`yarn babel-node test/${testFile}`, {}, (error, stdout, stderr) => {
       console.log(`Running test ${testFile}`)
       if (error) {
-        console.error('Error running test', testFile, stdout.toString())
+        console.error('Error running test', testFile, stderr.toString())
         reject(new Error('test exit code: ' + String(error.code)))
       } else {
         resolve()

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -27,7 +27,7 @@ const runTest = (testFile: string): Promise<void> => {
 // Add new test files to this list
 const tests = [
   'base-path.js',
-  'custom-import.js',
+  'custom-gen-with-import.js',
   'exhaustive-union.js',
   'flow-strict.js',
   'imports.js',

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -1,9 +1,19 @@
 // @flow strict
 import { exec } from 'child_process'
+import {
+  always,
+  identity,
+  ifElse,
+  intersection,
+  isEmpty,
+  map,
+  pipe,
+} from 'ramda'
 
 const runTest = (testFile: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     const process = exec(`yarn babel-node test/${testFile}`, {}, (error, stdout, sterr) => {
+      console.log(`Running test ${testFile}`)
       if (error) {
         console.error('Error running test', testFile, stdout.toString())
         reject(new Error('test exit code: ' + String(error.code)))
@@ -14,14 +24,30 @@ const runTest = (testFile: string): Promise<void> => {
   })
 }
 
-Promise.all([
-  runTest('base-path.js'),
-  runTest('exhaustive-union.js'),
-  runTest('flow-strict.js'),
-  runTest('imports.js'),
-  runTest('maybe.js'),
-  runTest('preamble.js'),
-]).then(() => {
+// Add new test files to this list
+const tests = [
+  'base-path.js',
+  'custom-import.js',
+  'exhaustive-union.js',
+  'flow-strict.js',
+  'imports.js',
+  'maybe.js',
+  'preamble.js',
+]
+
+const selectedTests = process.argv.slice(2)
+
+const testPromises = pipe(
+  ifElse(
+    isEmpty,
+    always(tests),
+    identity,
+  ),
+  intersection(tests),
+  map(runTest),
+)
+
+Promise.all(testPromises(selectedTests)).then(() => {
   console.log('All tests passed!')
   process.exit(0)
 }).catch(() => {


### PR DESCRIPTION
This adds a test for a custom generator that imports a function as part of it's `CodeGenDep` (this test is fairly similar to a test being added in pr #13 and also has a small weirdsy in it, so it may need some additional tweaking).

The section on building custom generators has been updated to hopefully be more clear, especially when it comes to `CustomType` and `CustomImport`. I also noticed a few areas of the documentation that were out-of-date an updated them as well as killing a few typos.

Lastly, `test-suite.js` has been made a bit smarter and you can now specify which test file(s) you want to run:

```
$ yarn test maybe.js
Running test maybe.js
All tests passed!
✨  Done in 5.00s.

$ yarn test preamble.js imports.js
Running test preamble.js
Running test imports.js
All tests passed!
✨  Done in 1.89s.
```

After this is merged I think issue #12 can be closed out.