### PR TITLE
Export degenMapping So It's Usable

### DIFF
--- a/src/base-gen.js
+++ b/src/base-gen.js
@@ -33,6 +33,7 @@ const baseImportLocations: {[import: DeImport]: string} = {
   deBool: 'flow-degen',
   deField: 'flow-degen',
   deList: 'flow-degen',
+  deMapping: 'flow-degen',
   deNumber: 'flow-degen',
   deString: 'flow-degen',
   stringify: 'flow-degen',

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ export {
   degenField,
   degenFilePath,
   degenList,
+  degenMapping,
   degenMaybe,
   degenNumber,
   degenObject,

--- a/test/mapping.js
+++ b/test/mapping.js
@@ -1,0 +1,55 @@
+// @flow strict
+import assert from 'assert'
+import path from 'path'
+import {
+  degenField,
+  degenMapping,
+  degenObject,
+  degenString,
+} from '../src/index.js'
+import { runFlow } from './utils.js'
+import { codeGen } from '../src/base-gen.js'
+
+// Workaround for https://github.com/LoganBarnett/flow-degen/issues/15
+export type Container = {
+  mapping: { [string]: string },
+}
+
+const containerMetaType = { name: 'Container', typeParams: [] }
+
+const mappingContainerGenerator = () => degenObject(
+  containerMetaType,
+  [degenField('mapping', degenMapping(degenString(), degenString()))],
+  [],
+)
+
+const code = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'Container': __filename,
+  },
+  {
+    deField: '../src/deserializer.js',
+    deMapping: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+  },
+  [
+    [
+      path.resolve(__dirname, 'mapping-output.js'), [
+        [ 'mappingContainerRefiner', mappingContainerGenerator() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(code).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -38,6 +38,7 @@ const tests = [
   'exhaustive-union.js',
   'flow-strict.js',
   'imports.js',
+  'mapping.js',
   'maybe.js',
   'object-optional-fields.js',
   'preamble.js',


### PR DESCRIPTION
Added degenMapping to src/index.js so that flow-degen users can make use
of it.