### PR TITLE
fix issue where opaque and complex types fail to type check

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,8 +9,19 @@
 * changelog
 ** Upcoming
 *** Breaking
+    1. =degenList=, =degenMapping=, and =degenRefiner= all now require
+       =MetaType= information in the leading parameters. In the case of
+       =degenMapping= there are two (key and value). The "Fixes" section
+       outlines the motivations.
 *** Additions
 *** Fixes
+    1. We are now explicitly using types at the call sites for =degenList=,
+       =degenMapping=, and =degenRefiner=. This should reduce the level of type
+       inferencing the generated refiners place upon Flow, and in many cases
+       will reduce errors outright because Flow just didn't have enough to go
+       off of. See the "Breaking" section for details as to how this breaks the
+       interfaces for these functions, and how you can address it.
+
 ** 0.16.0
 *** Breaking
     1. =degenObject= now takes a list of optional fields as a new argument at

--- a/README.org
+++ b/README.org
@@ -128,7 +128,8 @@ yarn add -E -D flow-degen
      #+begin_src js
        import { degenList, degenNumber} from 'flow-degen'
 
-       export const foosGenerator = () => degenList(degenNumber())
+       const numberType = { name: 'number', typeParams: [] }
+       export const foosGenerator = () => degenList(numberType, degenNumber())
      #+end_src
 
      Upon importing the emitted file, you can now refine into an =Array= of
@@ -156,8 +157,8 @@ yarn add -E -D flow-degen
 
 **** degenMapping
      A "mapping" is of the type ={[A]: B}= although usually it will be
-     ={[string]: mixed}=. It takes a key deserializer and a value deserializer
-     for =A= and =B= respectively.
+     ={[string]: mixed}=. It takes the key meta type, the value meta type, a key
+     deserializer, and a value deserializer for =A= and =B= respectively.
 **** degenMaybe
      The =degenMaybe= generator is for creating refiners for maybe types (e.g.
      type Foo = ?string). The maybe type will still require additional
@@ -319,9 +320,11 @@ yarn add -E -D flow-degen
          degenRefiner,
        } from 'flow-degen'
 
+       // This is the same fooType in foo-generator.js, and could be imported.
+       const fooType = { name: 'Foo', typeParams: [] }
        const barType = { name: 'Bar', typeParams: [] }
        export const fooGenerator = () => degenObject(barType, [
-         degenField('foo', degenRefiner('deFoo')),
+         degenField('foo', degenRefiner(fooType, 'deFoo')),
        ])
      #+end_src
 
@@ -367,6 +370,10 @@ yarn add -E -D flow-degen
       =./src/generator.js= does this for you. It is found by =flow-degen=
       consumers as a top-level export (=import { mergeDeps } from
       'flow-degen'=).
+    + Try testing your refiner with an opaque type. This seems to be a good way
+      to ensure Flow cannot run into issues with type inferencing. We suspect
+      this is a good test because opaque types can never be inferred, and
+      therefore will always need explicit types at the call site of a refiner.
 
     Let's create an custom generator example where we have an uppercase string.
 

--- a/src/config-generator.js
+++ b/src/config-generator.js
@@ -32,11 +32,30 @@ const configGeneratorType = { name: 'ConfigGenerator', typeParams: []}
 export const degenConfig = () => degenObject<string, string>(configType, [
   degenField('baseDir', degenFilePath()),
   degenField('generatedPreamble', degenString()),
-  degenField('typeLocations', degenMapping(degenString(), degenFilePath())),
-  degenField('importLocations', degenMapping(degenString(), degenFilePath())),
-  degenField('generators', degenList(degenObject(configGeneratorType, [
-    degenField('exports', degenMapping(degenString(), degenString())),
-    degenField('inputFile', degenFilePath()),
-    degenField('outputFile', degenFilePath()),
-  ], []))),
+  degenField('typeLocations', degenMapping(
+    stringType,
+    stringType,
+    degenString(),
+    degenFilePath(),
+  )),
+  degenField('importLocations', degenMapping(
+    stringType,
+    stringType,
+    degenString(),
+    degenFilePath(),
+  )),
+  degenField('generators', degenList(
+    configGeneratorType,
+    degenObject(configGeneratorType, [
+      degenField('exports', degenMapping(
+        stringType,
+        stringType,
+        degenString(),
+        degenString(),
+      )),
+      degenField('inputFile', degenFilePath()),
+      degenField('outputFile', degenFilePath()),
+    ],
+    [],
+  ))),
 ], [])

--- a/src/generator.js
+++ b/src/generator.js
@@ -154,27 +154,40 @@ export const degenField = <CustomType: string, CustomImport: string>(
 }
 
 export const degenList = <CustomType: string, CustomImport: string>(
+  metaType: MetaType<CustomType, CustomImport>,
   element: DeserializerGenerator<CustomType, CustomImport>,
 ): DeserializerGenerator<CustomType, CustomImport> => {
   const [elementDeserializer, deps] = element
   return [() => {
-    return `deList.bind(null, ${elementDeserializer()})`
+    return `(
+deList.bind(null, ${elementDeserializer()}):
+(mixed) => Array<${typeHeader(metaType)}> | Error
+)`
   }, mergeDeps<CustomType, CustomImport>(
     deps,
-    { types: [], imports: ['deList'], hoists: [] },
+    { types: [metaType], imports: ['deList'], hoists: [] },
   ),
   ]
 }
 
 export const degenMapping = <CustomType: string, CustomImport: string>(
+  keyMetaType: MetaType<CustomType, CustomImport>,
+  valueMetaType: MetaType<CustomType, CustomImport>,
   keyGenerator: DeserializerGenerator<CustomType, CustomImport>,
   valueGenerator: DeserializerGenerator<CustomType, CustomImport>,
 ): DeserializerGenerator<CustomType, CustomImport> => {
   const [keyDeserializer, keyDeps] = keyGenerator
   const [valueDeserializer, valueDeps] = valueGenerator
-  const deps = { types: [], imports: ['deMapping'], hoists: []}
+  const deps = {
+    types: [keyMetaType, valueMetaType],
+    imports: ['deMapping'],
+    hoists: [],
+  }
   return [
-    () => `deMapping.bind(null, ${keyDeserializer()}, ${valueDeserializer()})`,
+    () => `(
+deMapping.bind(null, ${keyDeserializer()}, ${valueDeserializer()}):
+(mixed) => { [${typeHeader(keyMetaType)}]: ${typeHeader(valueMetaType)} } | Error
+)`,
     mergeDeps<CustomType, CustomImport>(mergeDeps(keyDeps, valueDeps), deps),
   ]
 }
@@ -390,11 +403,12 @@ export const de = <CustomType: string, CustomImport: string>(
 }
 
 export const degenRefiner = <CustomType: string, CustomImport: string>(
+  refinerType: MetaType<CustomType, CustomImport>,
   refinerSymbol: CustomImport,
 ): DeserializerGenerator<CustomType, CustomImport> => {
   return [
     () => refinerSymbol,
-    { types: [], imports: [refinerSymbol], hoists: [] },
+    { types: [refinerType], imports: [refinerSymbol], hoists: [] },
   ]
 }
 

--- a/test/call-site-type-delist.js
+++ b/test/call-site-type-delist.js
@@ -1,0 +1,56 @@
+// @flow strict
+import assert from 'assert'
+import path from 'path'
+import {
+  degenList,
+  degenRefiner,
+  deNumber,
+} from '../src/index.js'
+import { runFlow } from './utils.js'
+import { codeGen } from '../src/base-gen.js'
+
+// This issue is easily reproduced with opaque types, but other, more
+// complicated types can also produce it.
+export opaque type Celcius = number
+
+export const refineCelcius = (x: mixed): Celcius | Error => {
+  return deNumber(x)
+}
+
+const celciusType = { name: 'Celcius', typeParams: [] }
+
+export const genRefineCelciusList = () => degenList<string, string>(
+  celciusType,
+  degenRefiner(celciusType, 'refineCelcius'),
+)
+
+const code = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'Celcius': __filename,
+  },
+  {
+    deList: '../src/deserializer.js',
+    deNumber: '../src/deserializer.js',
+    refineCelcius: __filename,
+  },
+  [
+    [
+      path.resolve(__dirname, 'call-site-type-delist-output.js'), [
+        [ 'reCelciusList', genRefineCelciusList() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(code).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})

--- a/test/call-site-type-demapping.js
+++ b/test/call-site-type-demapping.js
@@ -1,0 +1,60 @@
+// @flow strict
+import assert from 'assert'
+import path from 'path'
+import {
+  degenMapping,
+  degenRefiner,
+  degenString,
+  deNumber,
+} from '../src/index.js'
+import { runFlow } from './utils.js'
+import { codeGen } from '../src/base-gen.js'
+
+// This issue is easily reproduced with opaque types, but other, more
+// complicated types can also produce it.
+export opaque type Celcius = number
+
+export const refineCelcius = (x: mixed): Celcius | Error => {
+  return deNumber(x)
+}
+
+const celciusType = { name: 'Celcius', typeParams: [] }
+
+export const genRefineCelciusMapping = () => degenMapping<string, string>(
+  { name: 'string', typeParams: [] },
+  celciusType,
+  degenString(),
+  degenRefiner(celciusType, 'refineCelcius'),
+)
+
+const code = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'Celcius': __filename,
+  },
+  {
+    deMapping: '../src/deserializer.js',
+    deNumber: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+    refineCelcius: __filename,
+  },
+  [
+    [
+      path.resolve(__dirname, 'call-site-type-demapping-output.js'), [
+        [ 'reCelciusMapping', genRefineCelciusMapping() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(code).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})

--- a/test/call-site-type-opaque.js
+++ b/test/call-site-type-opaque.js
@@ -1,0 +1,51 @@
+// @flow strict
+import assert from 'assert'
+import path from 'path'
+import {
+  degenRefiner,
+  deNumber,
+} from '../src/index.js'
+import { runFlow } from './utils.js'
+import { codeGen } from '../src/base-gen.js'
+
+export opaque type Celcius = number
+
+export const refineCelcius = (x: mixed): Celcius | Error => {
+  return deNumber(x)
+}
+
+export const genRefineCelcius = () => degenRefiner<string, string>(
+  { name: 'Celcius', typeParams: [] },
+  'refineCelcius',
+)
+
+const code = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'Celcius': __filename,
+  },
+  {
+    deList: '../src/deserializer.js',
+    deNumber: '../src/deserializer.js',
+    refineCelcius: __filename,
+  },
+  [
+    [
+      path.resolve(__dirname, 'call-site-type-opaque-output.js'), [
+        [ 'reCelcius', genRefineCelcius() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(code).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})

--- a/test/imports.js
+++ b/test/imports.js
@@ -32,8 +32,8 @@ const fooGenerator = () => degenObject(fooType, [
 ], [])
 
 const barGenerator = () => degenObject(barType, [
-  degenField('b', degenRefiner('deFoo')),
-  degenField('bb', degenRefiner('deBaz'))
+  degenField('b', degenRefiner(fooType, 'deFoo')),
+  degenField('bb', degenRefiner(bazType, 'deBaz'))
 ], [])
 
 const bazGenerator = () => degenObject(bazType, [

--- a/test/mapping.js
+++ b/test/mapping.js
@@ -16,10 +16,16 @@ export type Container = {
 }
 
 const containerMetaType = { name: 'Container', typeParams: [] }
+const stringMetaType = { name: 'string', typeParams: [] }
 
 const mappingContainerGenerator = () => degenObject(
   containerMetaType,
-  [degenField('mapping', degenMapping(degenString(), degenString()))],
+  [degenField('mapping', degenMapping(
+    stringMetaType,
+    stringMetaType,
+    degenString(),
+    degenString(),
+  ))],
   [],
 )
 

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -25,6 +25,9 @@ const runTest = (testFile: string): Promise<void> => {
           )
           reject(new Error('test exit code: ' + String(error.code)))
         } else {
+          // Ideally we aren't depending on log output, but sometimes it's
+          // useful to debug even passing tests.
+          console.log(stdout.toString())
           resolve()
         }
       })
@@ -34,6 +37,9 @@ const runTest = (testFile: string): Promise<void> => {
 // Add new test files to this list
 const tests = [
   'base-path.js',
+  'call-site-type-delist.js',
+  'call-site-type-demapping.js',
+  'call-site-type-opaque.js',
   'custom-gen-with-import.js',
   'exhaustive-union.js',
   'flow-strict.js',
@@ -56,8 +62,10 @@ const testPromises = pipe(
   map(runTest),
 )
 
-Promise.all(testPromises(selectedTests)).then(() => {
-  console.log('All tests passed!')
+const testRuns = testPromises(selectedTests)
+Promise.all(testRuns).then(() => {
+  const size = testRuns.length
+  console.log(`All tests passed! ${size}/${size}`)
   process.exit(0)
 }).catch((error: mixed) => {
   console.error(


### PR DESCRIPTION
Fixes #15, fixes #17

When type inferencing becomes too much for Flow it will fail to type check. Similarly, opaque types can never be inferred. These changes should fix any issues where the type is missing at the call site of a refiner. It introduces breaking changes, unfortunately. We may want to consider that all refiners require meta types in order to operate.