### PR TITLE
Fix Error Running Flow Degen

### DIFF
--- a/flow-degen.js
+++ b/flow-degen.js
@@ -1,7 +1,9 @@
 #! /usr/bin/env node
 // @flow strict
 
+/*::
 import { typeof fileGen as FileGen } from './src/base-gen.js'
+*/
 const fs = require('fs')
 const path = require('path')
 // All of the files used here are transpiled, but this helps with consuming
@@ -21,7 +23,7 @@ require('@babel/register')(babelConfig)
 
 const R = require('ramda')
 
-const fileGen: FileGen<string, string> = require('./dist/base-gen.js').fileGen
+const fileGen /*: FileGen<string, string> */ = require('./dist/base-gen.js').fileGen
 const configDeserializer = require('./dist/config.deserializer.js').deConfig
 
 const configPath = process.argv[2]


### PR DESCRIPTION
The type annotations added to make sure that the call to fileGen in flow-degen.js is typed correctly break when running flow-degen as plain node does like the `import` or type annotation. The flow code is now wrapped in flow comment blocks so that node will ignore it. This seemed simpler than changing flow-degen.js to be transpiled by babel as part of flow-dist.sh.