### PR TITLE
Support Some Flow Utility Types

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -13,6 +13,8 @@
        =MetaType= information in the leading parameters. In the case of
        =degenMapping= there are two (key and value). The "Fixes" section
        outlines the motivations.
+    2. The =typeParams= field in =MetaType= has been made optional. This could
+       impact custom generators that use this field.
 *** Additions
 *** Fixes
     1. We are now explicitly using types at the call sites for =degenList=,
@@ -30,8 +32,6 @@
        before.
     2. =codeGen= takes a =prettify= flag as the second argument. Use =true= for
        this argument to keep your original behavior.
-    3. The =typeParams= field in =MetaType= has been made optional. This could
-       impact custom generators that use this field.
 *** Additions
     1. The =degenObject= generator now takes a list of optional fields so any
        field that is an optional type (not necessarily a maybe type) can also be

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -30,6 +30,8 @@
        before.
     2. =codeGen= takes a =prettify= flag as the second argument. Use =true= for
        this argument to keep your original behavior.
+    3. The =typeParams= field in =MetaType= has been made optional. This could
+       impact custom generators that use this field.
 *** Additions
     1. The =degenObject= generator now takes a list of optional fields so any
        field that is an optional type (not necessarily a maybe type) can also be

--- a/README.org
+++ b/README.org
@@ -344,7 +344,9 @@ yarn add -E -D flow-degen
     =src/generator.js= but at a minimum contains the type name:
 
     #+begin_src js
-    type Foo = {}
+    type Foo = {
+      bar: string,
+    }
 
     const fooType = { name: 'Foo' }
     #+end_src
@@ -361,9 +363,9 @@ yarn add -E -D flow-degen
     const fooType = { name: 'Foo', typeParams: [stringType, stringType]}
     #+end_src
 
-    Some types (for example, certain flow utility types) take literal strings or
-    numbers instead of a type. The =MetaType= has an optional =literal= boolean
-    to indicate these usages:
+    Some types (for example flow utility types like =$PropertyType=) take
+    literal strings or numbers instead of a type. The =MetaType= has an optional
+    =literal= boolean to indicate these usages:
 
     #+begin_src js
     type Foo = {
@@ -377,8 +379,8 @@ yarn add -E -D flow-degen
     const barType = { name: '$PropertyType', typeParams: [fooType, bazPropertyType] }
     #+end_src
 
-    Note that for string literals (and other literals with delimiters) need to
-    include the delimiters in the name ("'baz'" instead of "baz" or 'baz').
+    Note that string literals (and other literals with delimiters) need to
+    include the delimiters in the name (e.g. "'baz'" instead of "baz" or 'baz').
 
 *** building custom deserializer generators
     All deserializers must satisfy the following contract:

--- a/README.org
+++ b/README.org
@@ -336,6 +336,50 @@ yarn add -E -D flow-degen
      configuration file, or your configuration file must specify in the
      =imports= how to find this symbol.
 
+*** creating meta types
+
+    Objects of type =MetaType= are passed into many generator functions and
+    contain information =flow-degen= uses to build imports and type signatures
+    in the generated code. The =MetaType= type can be found in
+    =src/generator.js= but at a minimum contains the type name:
+
+    #+begin_src js
+    type Foo = {}
+
+    const fooType = { name: 'Foo' }
+    #+end_src
+
+    In the case of generic types, the optional =typeParams= field in =MetaType=
+    can be used to list the meta types to be specified in the type signature:
+
+    #+begin_src js
+    type Foo<K: string, V: string> = {
+      [K]: V,
+    }
+
+    const stringType = { name: 'string' }
+    const fooType = { name: 'Foo', typeParams: [stringType, stringType]}
+    #+end_src
+
+    Some types (for example, certain flow utility types) take literal strings or
+    numbers instead of a type. The =MetaType= has an optional =literal= boolean
+    to indicate these usages:
+
+    #+begin_src js
+    type Foo = {
+      bar: {
+        baz: string,
+      },
+    }
+
+    const fooType = { name: 'Foo' }
+    const bazPropertyType = { name: "'baz'", literal: true }
+    const barType = { name: '$PropertyType', typeParams: [fooType, bazPropertyType] }
+    #+end_src
+
+    Note that for string literals (and other literals with delimiters) need to
+    include the delimiters in the name ("'baz'" instead of "baz" or 'baz').
+
 *** building custom deserializer generators
     All deserializers must satisfy the following contract:
 

--- a/README.org
+++ b/README.org
@@ -174,8 +174,8 @@ yarn add -E -D flow-degen
      #+begin_src js
        import { degenObject, degenField, degenMaybe, degenString } from 'flow-degen'
 
-       const fooType = { name: 'Foo', typeParams: [] }
-       const stringType = { name: 'string', typeParams: [] }
+       const fooType = { name: 'Foo' }
+       const stringType = { name: 'string' }
        export const fooGenerator = () => degenObject(fooType, [
          degenField('bar', degenMaybe(stringType, degenString())),
        ])
@@ -221,7 +221,7 @@ yarn add -E -D flow-degen
          love?: number,
        }
 
-       const catType = { name: 'Cat', typeParams: [] }
+       const catType = { name: 'Cat' }
        const catGenerator = () => degenObject(catType, [
          degenField('demands', degenNumber()),
        ], [
@@ -304,7 +304,7 @@ yarn add -E -D flow-degen
      #+begin_src js
        import { degenObject, degenField, degenString } from 'flow-degen'
 
-       const fooType = { name: 'Foo', typeParams: [] }
+       const fooType = { name: 'Foo' }
        export const fooGenerator = () => degenObject(fooType, [
          degenField('first', degenString()),
          degenField('last', degenString()),
@@ -321,8 +321,8 @@ yarn add -E -D flow-degen
        } from 'flow-degen'
 
        // This is the same fooType in foo-generator.js, and could be imported.
-       const fooType = { name: 'Foo', typeParams: [] }
-       const barType = { name: 'Bar', typeParams: [] }
+       const fooType = { name: 'Foo' }
+       const barType = { name: 'Bar' }
        export const fooGenerator = () => degenObject(barType, [
          degenField('foo', degenRefiner(fooType, 'deFoo')),
        ])
@@ -408,7 +408,7 @@ yarn add -E -D flow-degen
             {
               hoists: [],
               imports: [ 'uppercase' ],
-              types: [ { name: 'UppercaseString', typeParams: [] } ],
+              types: [ { name: 'UppercaseString' } ],
             },
           ),
         ]

--- a/src/base-gen.js
+++ b/src/base-gen.js
@@ -40,9 +40,13 @@ const baseImportLocations: {[import: DeImport]: string} = {
 }
 
 const globalTypes: $ReadOnlyArray<DeType> = [
+  '$ElementType',
+  '$NonMaybeType',
+  '$PropertyType',
   'bool',
   'boolean',
   'function',
+  'literal',
   'number',
   'object',
   'string',

--- a/src/base-gen.js
+++ b/src/base-gen.js
@@ -46,7 +46,6 @@ const globalTypes: $ReadOnlyArray<DeType> = [
   'bool',
   'boolean',
   'function',
-  'literal',
   'number',
   'object',
   'string',

--- a/test/flow-utility-types.js
+++ b/test/flow-utility-types.js
@@ -19,7 +19,7 @@ export type ElementTypeTestContainer = {
   bar: ElementTypeTest,
 }
 
-const numberType = { name: 'number' }
+const numberType = { name: '1', literal: true }
 const elementTypeTestType = { name: 'ElementTypeTest' }
 const elementTypeTestContainerType = { name: 'ElementTypeTestContainer' }
 const elementTypeTestElementType = { name: '$ElementType', typeParams: [ elementTypeTestType, numberType ] }
@@ -27,7 +27,7 @@ const elementTypeTestElementType = { name: '$ElementType', typeParams: [ element
 const elementTypeTestContainerGenerator = () => degenObject(
   elementTypeTestContainerType,
   [
-    degenField('bar', degenList(
+    degenField('bar', degenList(elementTypeTestElementType,
       degenObject(elementTypeTestElementType, [
         degenField('foo', degenString()),
       ], [])
@@ -75,7 +75,7 @@ export type PropertyTypeTest = {
 }
 
 const propertyTypeTestType = { name: 'PropertyTypeTest' }
-const fooPropertyName = { name: 'literal', value: 'foo' }
+const fooPropertyName = { name: "'foo'", literal: true }
 const propertyTypeTestFooPropertyType = { name: '$PropertyType', typeParams: [ propertyTypeTestType, fooPropertyName ] }
 
 const propertyTypeTestGenerator = () => degenObject(
@@ -132,9 +132,10 @@ const nonMaybeTypeTestElementType = { name: '$ElementType', typeParams: [nonMayb
 const nonMaybeTypeTestGenerator = () => degenObject(
   nonMaybeTypeTestType,
   [], [
-    degenField('foo', degenList(degenObject(nonMaybeTypeTestElementType, [
-      degenField('bar', degenString())
-    ], [])))
+    degenField('foo', degenList(nonMaybeTypeTestElementType,
+      degenObject(nonMaybeTypeTestElementType, [
+        degenField('bar', degenString())
+      ], [])))
   ],
 )
 

--- a/test/flow-utility-types.js
+++ b/test/flow-utility-types.js
@@ -1,0 +1,170 @@
+// @flow strict
+import assert from 'assert'
+import path from 'path'
+import {
+  degenField,
+  degenList,
+  degenObject,
+  degenString,
+} from '../src/generator.js'
+import { runFlow } from './utils.js'
+import { codeGen } from '../src/base-gen.js'
+
+// Test $ElementType<T, K>, e.g. $ElementType<ElementTypeTest, number>
+export type ElementTypeTest = Array<{
+  foo: string,
+}>
+
+export type ElementTypeTestContainer = {
+  bar: ElementTypeTest,
+}
+
+const numberType = { name: 'number' }
+const elementTypeTestType = { name: 'ElementTypeTest' }
+const elementTypeTestContainerType = { name: 'ElementTypeTestContainer' }
+const elementTypeTestElementType = { name: '$ElementType', typeParams: [ elementTypeTestType, numberType ] }
+
+const elementTypeTestContainerGenerator = () => degenObject(
+  elementTypeTestContainerType,
+  [
+    degenField('bar', degenList(
+      degenObject(elementTypeTestElementType, [
+        degenField('foo', degenString()),
+      ], [])
+    ))
+  ], []
+)
+
+const elementTypeTestCode = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'ElementTypeTest': __filename,
+    'ElementTypeTestContainer': __filename,
+  },
+  {
+    deField: '../src/deserializer.js',
+    deList: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+  },
+  [
+    [
+      path.resolve(__dirname, 'flow-utility-types-output.js'), [
+        [ 'elementTypeTestContainerRefiner', elementTypeTestContainerGenerator() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(elementTypeTestCode).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})
+
+// Test $PropertyType<T, k>, e.g. $PropertyType<PropertyTypeTest, 'foo'>
+export type PropertyTypeTest = {
+  foo: {
+    bar: string,
+  }
+}
+
+const propertyTypeTestType = { name: 'PropertyTypeTest' }
+const fooPropertyName = { name: 'literal', value: 'foo' }
+const propertyTypeTestFooPropertyType = { name: '$PropertyType', typeParams: [ propertyTypeTestType, fooPropertyName ] }
+
+const propertyTypeTestGenerator = () => degenObject(
+  propertyTypeTestType,
+  [
+    degenField('foo', degenObject(propertyTypeTestFooPropertyType, [
+      degenField('bar', degenString())
+    ], []))
+  ], [],
+)
+
+const propertyTypeTestCode = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'PropertyTypeTest': __filename,
+  },
+  {
+    deField: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+  },
+  [
+    [
+      path.resolve(__dirname, 'flow-utility-types-output.js'), [
+        [ 'propertyTypeTestRefiner', propertyTypeTestGenerator() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(propertyTypeTestCode).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})
+
+// Test $NonMaybeType<T>, e.g. $ElementType<$NonMaybeType<$PropertyType<NonMaybeTypeTest, 'foo'>>, number>
+export type NonMaybeTypeTest = {
+  foo?: Array<{
+    bar: string,
+  }>
+}
+
+const nonMaybeTypeTestType = { name: 'NonMaybeTypeTest' }
+const nonMaybeTypeTestFooPropertyType = { name: '$PropertyType', typeParams: [ nonMaybeTypeTestType, fooPropertyName ] }
+const nonMaybeTypeTestNonMaybeType = { name: '$NonMaybeType', typeParams: [nonMaybeTypeTestFooPropertyType] }
+const nonMaybeTypeTestElementType = { name: '$ElementType', typeParams: [nonMaybeTypeTestNonMaybeType, numberType] }
+
+const nonMaybeTypeTestGenerator = () => degenObject(
+  nonMaybeTypeTestType,
+  [], [
+    degenField('foo', degenList(degenObject(nonMaybeTypeTestElementType, [
+      degenField('bar', degenString())
+    ], [])))
+  ],
+)
+
+const nonMaybeTypeTestCode = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'NonMaybeTypeTest': __filename,
+  },
+  {
+    deField: '../src/deserializer.js',
+    deList: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+  },
+  [
+    [
+      path.resolve(__dirname, 'flow-utility-types-output.js'), [
+        [ 'nonMaybeTypeTestRefiner', nonMaybeTypeTestGenerator() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(nonMaybeTypeTestCode).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})

--- a/test/flow-utility-types.js
+++ b/test/flow-utility-types.js
@@ -15,25 +15,16 @@ export type ElementTypeTest = Array<{
   foo: string,
 }>
 
-export type ElementTypeTestContainer = {
-  bar: ElementTypeTest,
-}
-
 const numberType = { name: '1', literal: true }
 const elementTypeTestType = { name: 'ElementTypeTest' }
-const elementTypeTestContainerType = { name: 'ElementTypeTestContainer' }
 const elementTypeTestElementType = { name: '$ElementType', typeParams: [ elementTypeTestType, numberType ] }
 
-const elementTypeTestContainerGenerator = () => degenObject(
-  elementTypeTestContainerType,
-  [
-    degenField('bar', degenList(elementTypeTestElementType,
-      degenObject(elementTypeTestElementType, [
-        degenField('foo', degenString()),
-      ], [])
-    ))
-  ], []
-)
+const elementTypeTestGenerator = () =>
+  degenList(elementTypeTestElementType,
+    degenObject(elementTypeTestElementType, [
+      degenField('foo', degenString()),
+    ], []),
+  )
 
 const elementTypeTestCode = codeGen(
   __dirname,
@@ -41,7 +32,6 @@ const elementTypeTestCode = codeGen(
   '',
   {
     'ElementTypeTest': __filename,
-    'ElementTypeTestContainer': __filename,
   },
   {
     deField: '../src/deserializer.js',
@@ -51,7 +41,7 @@ const elementTypeTestCode = codeGen(
   [
     [
       path.resolve(__dirname, 'flow-utility-types-output.js'), [
-        [ 'elementTypeTestContainerRefiner', elementTypeTestContainerGenerator() ],
+        [ 'elementTypeTestRefiner', elementTypeTestGenerator() ],
       ],
     ],
   ],

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -12,6 +12,7 @@ import {
 
 const runTest = (testFile: string): Promise<void> => {
   return new Promise((resolve, reject) => {
+    console.log(`Running test ${testFile}`)
     const process = exec(
       `yarn babel-node test/${testFile}`,
       {},
@@ -43,6 +44,7 @@ const tests = [
   'custom-gen-with-import.js',
   'exhaustive-union.js',
   'flow-strict.js',
+  'flow-utility-types.js',
   'imports.js',
   'mapping.js',
   'maybe.js',

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -12,7 +12,6 @@ import {
 
 const runTest = (testFile: string): Promise<void> => {
   return new Promise((resolve, reject) => {
-    console.log(`Running test ${testFile}`)
     const process = exec(
       `yarn babel-node test/${testFile}`,
       {},


### PR DESCRIPTION
This change adds support for representing some Flow utility types (`$PropertyType`, `$ElementType` and `$NonMaybeType`) as a `MetaType` in `flow-degen`. As `$PropertyType` and `$ElementType` take literal values (property names and array indexes), the `MetaType` type has a new optional boolean property that indicates if the `MetaType` represents a type or a literal. Literal types don't get flattened (so they don't get added to an import declaration) but are otherwise usable where other `MetaType` objects are usable.

This change also makes `typeParams` in `MetaType` optional to make creating a `MetaType` object a little less verbose for non-parameterized types. This change is called out in the breaking changes section, as a generator that accesses `typeParams` will need to be updated to check for the property's existence.

Fixes #20 