### PR TITLE
Fix Degen Enum When Used with Utility Types

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -13,6 +13,9 @@
 *** Additions
 
 *** Fixes
+    1. A bug was introduced in the recent addition of Flow utility type support.
+       When =degenEnum= was used with a $PropertyType a syntax error would occurr
+       due to unescaped quote characters. This bug is now fixed.
 
 ** 0.17.0
 *** Breaking

--- a/src/generator.js
+++ b/src/generator.js
@@ -228,10 +228,14 @@ export const degenEnum = <CustomType: string, CustomImport: string>(
     const check = values.map(x => `'${x}'`).join(' === either || ') + ' === either'
     const oneOf = values.join(', ')
     const typeName = degenType<CustomType, CustomImport>(deType)[0]()
+    // Some Flow utility types can have string literals in them (e.g. property
+    // names) so we'll insert some escape characters so that the type name will
+    // be correctly escaped when used in the error message below.
+    const safeTypeName = typeName.replace(/'/g, "\\'")
     return `(v: mixed): ${typeName} | Error => {
   const either = ${stringGen()}(v)
   if(either instanceof Error) {
-    return new Error('Could not deserialize "' + String(v) +'" into enum "${typeName}":' + either.message)
+    return new Error('Could not deserialize "' + String(v) +'" into enum "${safeTypeName}":' + either.message)
   }
   else {
     if(${check}) {

--- a/test/flow-utility-types.js
+++ b/test/flow-utility-types.js
@@ -2,11 +2,12 @@
 import assert from 'assert'
 import path from 'path'
 import {
+  degenEnum,
   degenField,
   degenList,
   degenObject,
   degenString,
-} from '../src/generator.js'
+} from '../src/index.js'
 import { runFlow } from './utils.js'
 import { codeGen } from '../src/base-gen.js'
 
@@ -151,6 +152,55 @@ const nonMaybeTypeTestCode = codeGen(
 )[0][1]
 
 runFlow(nonMaybeTypeTestCode).then((errorText) => {
+  assert.ok(
+    errorText.match(/No errors!/),
+    'Expected no errors in flow check but got errors:' + errorText,
+  )
+}).catch((e: mixed) => {
+  console.error('Error running test:', e)
+  process.exit(1)
+})
+
+// Test $PropertyType<T, k>, e.g. $PropertyType<PropertyTypeTest, 'foo'> with an enum
+export type EnumPropertyTypeTest = {
+  foo: 'bar' | 'baz'
+}
+
+const enumPropertyTypeTestType = { name: 'EnumPropertyTypeTest' }
+const enumFooPropertyName = { name: "'foo'", literal: true }
+const enumPropertyTypeTestFooPropertyType = { name: '$PropertyType', typeParams: [ enumPropertyTypeTestType, enumFooPropertyName ] }
+
+const enumPropertyTypeTestGenerator = () => degenObject(
+  enumPropertyTypeTestType,
+  [
+    degenField('foo', degenEnum(enumPropertyTypeTestFooPropertyType, [
+      'bar',
+      'baz',
+    ]))
+  ], [],
+)
+
+const enumPropertyTypeTestCode = codeGen(
+  __dirname,
+  true,
+  '',
+  {
+    'EnumPropertyTypeTest': __filename,
+  },
+  {
+    deField: '../src/deserializer.js',
+    deString: '../src/deserializer.js',
+  },
+  [
+    [
+      path.resolve(__dirname, 'flow-utility-types-output.js'), [
+        [ 'enumPropertyTypeTestRefiner', enumPropertyTypeTestGenerator() ],
+      ],
+    ],
+  ],
+)[0][1]
+
+runFlow(enumPropertyTypeTestCode).then((errorText) => {
   assert.ok(
     errorText.match(/No errors!/),
     'Expected no errors in flow check but got errors:' + errorText,


### PR DESCRIPTION
Changes the degenEnum function to replace quote characters with escaped
quote characters in the string form of the type name. Some Flow utility
types can have literal strings in them, which led to the generated
refiner code having syntax errors.