### PR TITLE
use Ramda mergeRight and fix Flow recursion issues

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,8 @@
-module.exports = {
+// @flow strict
+/*::
+import { type Options } from '@babel/register'
+*/
+module.exports = ({
   plugins: [ '@babel/plugin-transform-modules-commonjs' ],
   presets: [ '@babel/preset-flow' ],
-}
+}/*: Options */)

--- a/flow-degen.js
+++ b/flow-degen.js
@@ -8,11 +8,8 @@ const fs = require('fs')
 const path = require('path')
 // All of the files used here are transpiled, but this helps with consuming
 // files provided by the library consumer.
-const babelConfig = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, './.babelrc'), 'utf8')
-)
+const babelConfig = require('./babel.config.js')
 
-babelConfig.babelrcRoots = __dirname
 babelConfig.ignore = [
   path.resolve(__dirname, '.git'),
   path.resolve(__dirname, 'flow-typed'),
@@ -68,10 +65,10 @@ else {
       true,
       configFile.generatedPreamble,
       configFile.typeLocations,
-      R.merge(
+      R.mergeRight/*:: <{[string]: string}, {[string]: string}> */(
         configFile.importLocations,
         R.mergeAll(
-          R.reduce(
+          R.reduce/*:: <Array<{[string]: string}>, Array<{[string]: string}>> */(
             R.concat,
             [],
             R.map(g => {

--- a/src/generator.js
+++ b/src/generator.js
@@ -4,7 +4,7 @@ import {
   concat,
   length,
   map,
-  merge,
+  mergeRight,
   pipe,
   prop,
   reduce,

--- a/src/generator.js
+++ b/src/generator.js
@@ -4,7 +4,6 @@ import {
   concat,
   length,
   map,
-  mergeRight,
   pipe,
   prop,
   reduce,


### PR DESCRIPTION
Ramda's `merge` no longer exists. After switching to `mergeRight`, I ran into recursion limit issues. This is unlikely to be `mergeRight`'s doing, as it is the same definition. That said, the Ramda libdef might be more complicated, or perhaps the latest Flow is less tolerant of recursion in the definitions.

Additionally, we shouldn't have to set `babelrcRoots` anymore in part because we're not using `.babelrc` anymore. The `.babelrc` file has different behavior from `babel.config.js` relating to how they are employed across subdirectories and nesting. I haven't confirmed this, and have instead leaned on the type definition for the Babel config (`Options`) to define this.

It would be nice to make sure our pre-merge tests caught this. Perhaps it's time to look at a Travis-CI configuration. Also `yarn test` didn't fail with `merge`, which I find perplexing. Perhaps the deprecated `merge` still exists? I don't think it's possible for us to not have exercised `merge`/`mergeRight`, given that it is used in `flow-degen.sh` and other places. But maybe! Test coverage could be another thing to pursue.