### PR TITLE
add github action release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.JS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: yarn install
+      - run: yarn test
+      - run: ./changelog-bump.js
+      - run: git add CHANGELOG.org
+      - run: git config --global user.email "tip@gha"
+      - run: git config --global user.name "GHA"
+      - run: yarn version --new-version minor
+      - run: yarn prepare
+      - run: git push && git push --tags
+      - run: yarn publish
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      # Github Actions catches this as an orphaned process, but let's be a good
+      # citizen and clean up after ourselves.
+      - run: yarn flow stop

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,6 +8,7 @@
 
 * changelog
 ** Upcoming
+** 0.19.0
 *** Breaking
 *** Additions
 *** Fixes
@@ -15,7 +16,9 @@
    maintenance life a little easier, and consumption is now easier for folks who
    want to iterate on a branch of =flow-degen=.
 2. Fix a syntax error in one of the examples (no executable change).
-3. Apply a security bump from dependabot. No actual vulnerabilities were fixed.
+3. Upgrade various build time dependencies - no runtime vulnerabilities were
+   addressed (and none known).
+4. Add Github Actions!
 
 ** 0.18.0
 *** Breaking

--- a/changelog-bump.js
+++ b/changelog-bump.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * A CLI script for bumping the changelog automatically.
+ *
+ * It marks the "Upcoming" section as the new version, and creates a new
+ * Upcoming section.
+ */
+const fs = require('fs').promises
+
+const { versionGet } = require('./version.js')
+
+versionGet().then(version => {
+  return fs
+    .readFile('CHANGELOG.org', 'utf8')
+    .then(d => d.replace(
+      new RegExp(
+        '^\\*\\* (Upcoming)(.+?)\\n\\*\\* 0\\.' + version + '\\.0',
+        'sm',
+      ),
+      `** Upcoming
+** 0.${version + 1}.0$2
+** 0.${version}.0`,
+      // (match, upcoming, old, offset, string, groups) => {
+
+      // }
+    ))
+})
+  .then(d => fs.writeFile('CHANGELOG.org', d, { encoding: 'utf8' }))
+  .then(() => console.error('CHANGELOG.org updated!'))

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "flow-degen",
-  "version": "0.18.0",
+  "version": "0.20.0",
   "description": "Generate (Flow) type safe deserializers in Javascript.",
   "homepage": "https://github.com/loganbarnett/flow-degen",
   "main": "dist/index.js",
+  "files": "dist/**/*",
   "bin": {
     "flow-degen": "./flow-degen.js"
   },

--- a/version.js
+++ b/version.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * A CLI script for getting the minor version number of the package. Pass -n to
+ * increment the version number.
+ *
+ * This is a Node.JS program to be platform agnostic an avoid some squirrelly
+ * shell beavior.
+ */
+const fs = require('fs').promises
+const process = require('process')
+
+module.exports = {
+  versionGet: () => {
+    return fs.readFile('package.json', 'utf8')
+      .then(JSON.parse)
+      .then(p => p.version.split('.')[1])
+      .then(parseInt)
+  },
+}
+
+module.exports.versionGet()
+  .then(v => v + process.argv.slice(2)[0] == '-n' ? 1 : 0)
+  .then(console.log)


### PR DESCRIPTION
Addresses #40 - add Github Action for handling releases.

This adds a workflow for tagging and publishing new packages for
flow-degen using Github Actions. This is done in hopes of automating
some of the publishing, which should occur far more frequently than it
has due to all of the dependabot security updates.

See https://github.com/actions/setup-node for some inspiration here,
though examples were taken from many other sources.