### PR TITLE
fix build.js failing in index.js.flow

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -13,6 +13,7 @@
 *** Fixes
 1. Build process now transpiles all files. All dist files now work as Common.JS
    rather than a mix of Common.JS and ES6 modules.
+2. Fix build process when =index.js.flow= is not present on disk.
 ** 0.19.0
 *** Breaking
 *** Additions

--- a/build.js
+++ b/build.js
@@ -66,8 +66,8 @@ Promise.resolve()
  * root ./index.js.flow workaround (see below) fixes the problem. These fixes
  * can coexist.
  */
-  .then(() => fs.copyFile.bind('src/index.js', 'index.js.flow'))
-  .then(() => fs.copyFile.bind('src/index.js', 'dist/index.js.flow'))
+  .then(() => fs.copyFile('src/index.js', './index.js.flow'))
+  .then(() => fs.copyFile('src/index.js', './dist/index.js.flow'))
 /**
  * When doing import {...} from 'flow-degen', Flow looks at the root directory
  * first, and finds index.js.flow. It's just a copy of our original


### PR DESCRIPTION
I must've gotten away with this working previously because index.js.flow
was present on disk. The bug was that we were binding a function to do
the file copy rather than executing that function to do the copy.

This should fix our publish action failing.