### PR TITLE
use new Flow error output

### DIFF
--- a/test/exhaustive-union.js
+++ b/test/exhaustive-union.js
@@ -91,7 +91,9 @@ runFlow(code).then((errorText) => {
     'Expected error where type Baz is not in union type Union in:\n' + errorText,
   )
   assert.ok(
-    errorText.match(/string literal `baz` \[1] is incompatible with enum \[2]./),
+    errorText.match(
+      /string literal `baz` \[1] is incompatible with literal union \[2]./,
+    ),
     'Expected error where "baz" literal is not in union UnionKind in:\n' + errorText,
   )
 }).catch((e: mixed) => {


### PR DESCRIPTION
Between Flow versions, the error message changed enough to break our
tests. This keeps us up with the new error. This should fix our build
pipeline and allow official versions to get released again.